### PR TITLE
chore(publish): harden @zdenekkurecka/astro-consent for MVP release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,37 @@
 name: Publish @zdenekkurecka/astro-consent
 
-# Publishes the package to npm.
+# Publishes the package to npm using npm Trusted Publishing (OIDC).
 #
-# Triggers:
-#   - push of a tag matching `astro-consent-v*` (e.g. `astro-consent-v0.1.0`)
+# No long-lived credentials are stored anywhere. At publish time, GitHub
+# issues a short-lived OIDC token, the npm CLI exchanges it for a one-shot
+# registry credential, and the tarball is published with a provenance
+# attestation so the npm page shows "Built and signed on GitHub Actions".
+#
+# ─── One-time setup on npmjs.com ─────────────────────────────────────────
+#
+# 1. Publish 0.1.0 manually once to create the package on npm (see README).
+#    After the package exists, anyone with owner access to it can configure
+#    a trusted publisher.
+#
+# 2. https://www.npmjs.com/package/@zdenekkurecka/astro-consent/access
+#    → "Trusted Publisher" → "Add trusted publisher" → GitHub Actions
+#
+#    Fill in:
+#      Organization or user:  zdenekkurecka
+#      Repository:            astro-consent
+#      Workflow filename:     publish.yml        ← must match this file
+#      Environment:           (leave empty unless you add one below)
+#
+#    Save. npm will now accept OIDC publishes from runs of this workflow
+#    on this repo.
+#
+# No repo secrets are needed. If you see `ENEEDAUTH` or `E401` on publish,
+# the most common cause is a mismatch between the values above and the
+# actual workflow that ran (branch, filename, repo name).
+#
+# ─── Triggers ─────────────────────────────────────────────────────────────
+#   - push of a tag matching `astro-consent-v*` (e.g. `astro-consent-v0.1.1`)
 #   - manual run from the Actions tab (useful for re-runs / dry-runs)
-#
-# Required repo secret: NPM_TOKEN
-#   1. https://www.npmjs.com/settings/<you>/tokens → Generate New Token →
-#      Classic → type: Automation (bypasses 2FA, which is what CI needs)
-#   2. GitHub repo → Settings → Secrets and variables → Actions →
-#      New repository secret → name: NPM_TOKEN
-#
-# The `id-token: write` permission is here for a future upgrade to npm
-# trusted publishing / provenance; today's workflow does not use it.
 
 on:
   push:
@@ -22,10 +40,13 @@ on:
   workflow_dispatch:
     inputs:
       dry-run:
-        description: 'Run without actually publishing (pnpm publish --dry-run)'
+        description: 'Run without actually publishing (npm publish --dry-run)'
         type: boolean
         default: false
 
+# Minimum permissions for OIDC trusted publishing:
+#   - id-token: write → lets the runner request an OIDC token for npm to verify
+#   - contents: read  → needed by actions/checkout
 permissions:
   contents: read
   id-token: write
@@ -48,11 +69,14 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          # registry-url writes an .npmrc that authenticates with
-          # NODE_AUTH_TOKEN against the public npm registry. Without this
-          # the NPM_TOKEN secret would be ignored.
+          # npm Trusted Publishing + provenance requires a reasonably recent
+          # npm CLI (>= 11.5.1). Node 22 ships npm 10.x, so we upgrade npm
+          # explicitly below.
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm to a version with Trusted Publishing support
+        run: npm install --global npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -78,14 +102,12 @@ jobs:
       - name: Smoke-test integration via playground build
         run: pnpm --filter playground build
 
-      - name: Publish to npm
+      - name: Publish to npm (with provenance)
         working-directory: packages/astro-consent
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ "${{ github.event.inputs.dry-run }}" = "true" ]; then
             echo "Dry run — not publishing"
-            pnpm publish --dry-run --no-git-checks
+            npm publish --dry-run --provenance --access public
           else
-            pnpm publish --no-git-checks
+            npm publish --provenance --access public
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,91 @@
+name: Publish @zdenekkurecka/astro-consent
+
+# Publishes the package to npm.
+#
+# Triggers:
+#   - push of a tag matching `astro-consent-v*` (e.g. `astro-consent-v0.1.0`)
+#   - manual run from the Actions tab (useful for re-runs / dry-runs)
+#
+# Required repo secret: NPM_TOKEN
+#   1. https://www.npmjs.com/settings/<you>/tokens → Generate New Token →
+#      Classic → type: Automation (bypasses 2FA, which is what CI needs)
+#   2. GitHub repo → Settings → Secrets and variables → Actions →
+#      New repository secret → name: NPM_TOKEN
+#
+# The `id-token: write` permission is here for a future upgrade to npm
+# trusted publishing / provenance; today's workflow does not use it.
+
+on:
+  push:
+    tags:
+      - 'astro-consent-v*'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Run without actually publishing (pnpm publish --dry-run)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Build, verify and publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.8.1
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          # registry-url writes an .npmrc that authenticates with
+          # NODE_AUTH_TOKEN against the public npm registry. Without this
+          # the NPM_TOKEN secret would be ignored.
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm --filter @zdenekkurecka/astro-consent build
+
+      - name: Verify tag matches package.json version
+        if: startsWith(github.ref, 'refs/tags/astro-consent-v')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#astro-consent-v}"
+          PKG_VERSION="$(node -p "require('./packages/astro-consent/package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Tag matches package.json: $PKG_VERSION"
+
+      - name: Lint published package shape (publint)
+        working-directory: packages/astro-consent
+        run: pnpm dlx publint@latest
+
+      - name: Smoke-test integration via playground build
+        run: pnpm --filter playground build
+
+      - name: Publish to npm
+        working-directory: packages/astro-consent
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ "${{ github.event.inputs.dry-run }}" = "true" ]; then
+            echo "Dry run — not publishing"
+            pnpm publish --dry-run --no-git-checks
+          else
+            pnpm publish --no-git-checks
+          fi

--- a/packages/astro-consent/LICENSE
+++ b/packages/astro-consent/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 zdenekkurecka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/astro-consent/README.md
+++ b/packages/astro-consent/README.md
@@ -1,0 +1,138 @@
+# @zdenekkurecka/astro-consent
+
+An Astro integration for GDPR/ePrivacy-friendly cookie consent. Ships a consent
+banner, a preferences modal, a small runtime API, and category-based consent
+state persisted in `localStorage`.
+
+- Zero-dependency runtime
+- Works with Astro's View Transitions / SPA routing (`astro:page-load`)
+- Versioned consent — bump `version` to re-prompt users
+- Typed config and runtime API
+- CSS is shipped as a single stylesheet that the integration injects for you
+
+## Install
+
+```sh
+# pnpm
+pnpm add @zdenekkurecka/astro-consent
+# npm
+npm install @zdenekkurecka/astro-consent
+# yarn
+yarn add @zdenekkurecka/astro-consent
+```
+
+Peer dependency: `astro@^5 || ^6`.
+
+## Usage
+
+Add the integration to `astro.config.*`:
+
+```ts
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import cookieConsent from '@zdenekkurecka/astro-consent';
+
+export default defineConfig({
+  integrations: [
+    cookieConsent({
+      version: 1,
+      categories: {
+        essential: {
+          label: 'Essential',
+          description: 'Required for the site to function.',
+          default: true,
+        },
+        analytics: {
+          label: 'Analytics',
+          description: 'Helps us understand how the site is used.',
+          default: false,
+        },
+        marketing: {
+          label: 'Marketing',
+          description: 'Used to personalize ads.',
+          default: false,
+        },
+      },
+      onConsent(state) {
+        // Fired once per session after the user has given (or already has) consent.
+        if (state.categories.analytics) {
+          // load analytics
+        }
+      },
+      onChange(state) {
+        // Fired when the user updates their preferences.
+        console.log('consent updated', state);
+      },
+    }),
+  ],
+});
+```
+
+The integration:
+
+1. Registers a Vite plugin that exposes the config via a virtual module.
+2. Injects the CSS inline into `<head>` (so there is no flash of unstyled banner).
+3. Injects a small client entry on every page that renders the banner / modal
+   and wires up event delegation.
+
+### Triggering UI from your own buttons
+
+Any element with a `data-cc` attribute is handled by the delegated listener:
+
+```html
+<button data-cc="accept-all">Accept all</button>
+<button data-cc="reject-all">Reject all</button>
+<button data-cc="manage">Manage preferences</button>
+```
+
+### Runtime API
+
+A global `window.zdenekkureckaConsent` is exposed:
+
+```ts
+interface ConsentAPI {
+  get(): ConsentState | null;
+  set(categories: Partial<Record<string, boolean>>): void;
+  reset(): void;
+  show(): void;
+  showPreferences(): void;
+}
+```
+
+Example:
+
+```ts
+// Read current state
+const state = window.zdenekkureckaConsent.get();
+
+// Programmatically update
+window.zdenekkureckaConsent.set({ analytics: true });
+
+// Re-open the preferences modal (e.g. from a "Cookie settings" footer link)
+window.zdenekkureckaConsent.showPreferences();
+
+// Clear consent and re-prompt
+window.zdenekkureckaConsent.reset();
+```
+
+### Styling
+
+The base stylesheet is injected automatically. If you want to import it
+yourself (e.g. to bundle it into your own CSS pipeline), it is exposed via a
+subpath export:
+
+```ts
+import '@zdenekkurecka/astro-consent/styles';
+```
+
+The styles use CSS custom properties so you can theme them from your own CSS.
+
+### Versioning consent
+
+Bump the `version` in the integration config whenever your categories change
+in a way that requires re-asking users. Any stored consent with a lower
+version is treated as missing, and the banner will be re-shown.
+
+## License
+
+MIT

--- a/packages/astro-consent/README.md
+++ b/packages/astro-consent/README.md
@@ -7,8 +7,13 @@ state persisted in `localStorage`.
 - Zero-dependency runtime
 - Works with Astro's View Transitions / SPA routing (`astro:page-load`)
 - Versioned consent — bump `version` to re-prompt users
-- Typed config and runtime API
-- CSS is shipped as a single stylesheet that the integration injects for you
+- Typed config, runtime API, and typed `document` event map
+- Accessible modal — `role="dialog"` / `aria-modal`, focus trap, focus
+  restoration, Escape to close
+- **Strict-CSP safe**: no inline `<script>`, no inline `<style>`. The runtime
+  is emitted as a hashed `<script type="module" src>` and the CSS as a
+  hashed `<link rel="stylesheet">` — works under `script-src 'self'` and
+  `style-src 'self'` without any `'unsafe-inline'`
 
 ## Install
 
@@ -37,11 +42,6 @@ export default defineConfig({
     cookieConsent({
       version: 1,
       categories: {
-        essential: {
-          label: 'Essential',
-          description: 'Required for the site to function.',
-          default: true,
-        },
         analytics: {
           label: 'Analytics',
           description: 'Helps us understand how the site is used.',
@@ -53,27 +53,61 @@ export default defineConfig({
           default: false,
         },
       },
-      onConsent(state) {
-        // Fired once per session after the user has given (or already has) consent.
-        if (state.categories.analytics) {
-          // load analytics
-        }
-      },
-      onChange(state) {
-        // Fired when the user updates their preferences.
-        console.log('consent updated', state);
-      },
     }),
   ],
 });
 ```
 
+> An `essential` category is always implicit — it's shown as a disabled
+> toggle in the modal and is always `true` in the consent state. You don't
+> need to (and shouldn't) declare it yourself.
+
 The integration:
 
-1. Registers a Vite plugin that exposes the config via a virtual module.
-2. Injects the CSS inline into `<head>` (so there is no flash of unstyled banner).
-3. Injects a small client entry on every page that renders the banner / modal
-   and wires up event delegation.
+1. Registers a Vite plugin that exposes the config to the client via a
+   virtual module (`virtual:astro-consent/init`).
+2. Injects the runtime via `injectScript('page', ...)` which Astro compiles
+   to a hashed `<script type="module" src="...">` — never inline.
+3. Injects the stylesheet via `injectScript('page-ssr', ...)` which routes
+   the CSS through Astro's normal CSS pipeline, emitting a hashed
+   `<link rel="stylesheet">` — never inline.
+
+### Reacting to consent changes
+
+Callbacks are delivered as typed `CustomEvent`s on `document`. Subscribe from
+a regular `<script>` tag in your layout or page — you have access to the full
+module scope (imports, closures, framework globals), unlike callbacks serialized
+through the integration config.
+
+```astro
+---
+// src/layouts/Layout.astro
+---
+<html>
+  <body>
+    <slot />
+    <script>
+      import { loadAnalytics, loadAds } from '../lib/trackers';
+
+      // Fired once per session after consent has been given (or after we
+      // detect an existing valid consent record on first page load).
+      document.addEventListener('astro-consent:consent', (e) => {
+        if (e.detail.categories.analytics) loadAnalytics();
+        if (e.detail.categories.marketing) loadAds();
+      });
+
+      // Fired when the user updates their preferences after the initial
+      // consent. Use this to tear down or re-enable trackers.
+      document.addEventListener('astro-consent:change', (e) => {
+        console.log('consent updated', e.detail);
+      });
+    </script>
+  </body>
+</html>
+```
+
+Both events are typed — adding this package as a dependency augments
+`DocumentEventMap` so `e.detail` is inferred as `ConsentState`.
 
 ### Triggering UI from your own buttons
 
@@ -117,15 +151,51 @@ window.zdenekkureckaConsent.reset();
 
 ### Styling
 
-The base stylesheet is injected automatically. If you want to import it
-yourself (e.g. to bundle it into your own CSS pipeline), it is exposed via a
-subpath export:
+The base stylesheet is injected automatically via Astro's CSS pipeline as a
+hashed `<link>`. If you want to import it yourself (e.g. to bundle it into
+your own CSS pipeline) it is exposed via a subpath export:
 
 ```ts
 import '@zdenekkurecka/astro-consent/styles';
 ```
 
-The styles use CSS custom properties so you can theme them from your own CSS.
+The styles use CSS custom properties so you can theme them from your own CSS:
+
+```css
+:where(#cc-container) {
+  --cc-primary: #7c3aed;
+  --cc-primary-hover: #6d28d9;
+  --cc-radius: 0.75rem;
+  --cc-font-family: 'Inter', sans-serif;
+}
+```
+
+### Accessibility
+
+- Modal has `role="dialog"` with `aria-modal="true"` and `aria-labelledby`
+  pointing at the visible title.
+- Opening the modal saves the previously focused element and moves focus to
+  the first control inside the dialog on the next animation frame.
+- `Tab` / `Shift+Tab` is trapped inside the modal while it is open.
+- `Escape` closes the modal and returns focus to the trigger.
+- Clicking the overlay closes the modal; the overlay itself is `aria-hidden`.
+- All buttons have `type="button"` so they never submit ambient forms.
+
+### Content Security Policy
+
+The integration is compatible with strict CSPs out of the box:
+
+```http
+Content-Security-Policy:
+  default-src 'self';
+  script-src  'self';
+  style-src   'self';
+```
+
+No `'unsafe-inline'` is required for either scripts or styles, because the
+integration only uses `injectScript('page', ...)` (emitted as a hashed
+external module script) and `injectScript('page-ssr', ...)` (which flows
+through Astro's CSS extractor and becomes a hashed external stylesheet).
 
 ### Versioning consent
 

--- a/packages/astro-consent/package.json
+++ b/packages/astro-consent/package.json
@@ -1,18 +1,55 @@
 {
   "name": "@zdenekkurecka/astro-consent",
   "version": "0.1.0",
+  "description": "Astro integration for GDPR/ePrivacy-friendly cookie consent: banner, preferences modal, runtime API and category-based consent state.",
+  "keywords": [
+    "astro",
+    "astro-integration",
+    "astro-component",
+    "cookie-consent",
+    "consent",
+    "gdpr",
+    "eprivacy",
+    "cookies",
+    "privacy",
+    "withastro"
+  ],
+  "author": "zdenekkurecka",
+  "license": "MIT",
+  "homepage": "https://github.com/zdenekkurecka/astro-consent#readme",
+  "bugs": {
+    "url": "https://github.com/zdenekkurecka/astro-consent/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zdenekkurecka/astro-consent.git",
+    "directory": "packages/astro-consent"
+  },
   "type": "module",
   "exports": {
-    ".": "./dist/index.js",
-    "./styles": "./dist/styles/base.css"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "default": "./dist/client.js"
+    },
+    "./styles": "./dist/styles/base.css",
+    "./styles/base.css": "./dist/styles/base.css",
+    "./package.json": "./package.json"
   },
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
-    "build": "tsc && mkdir -p dist/styles && cp src/styles/base.css dist/styles/base.css",
-    "dev": "tsc --watch"
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "pnpm run clean && tsc -p tsconfig.build.json && node scripts/copy-assets.mjs",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "prepublishOnly": "pnpm run build"
   },
   "peerDependencies": {
     "astro": "^5.0.0 || ^6.0.0"

--- a/packages/astro-consent/package.json
+++ b/packages/astro-consent/package.json
@@ -26,6 +26,12 @@
     "directory": "packages/astro-consent"
   },
   "type": "module",
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "engines": {
+    "node": ">=18.17.0"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/astro-consent/scripts/copy-assets.mjs
+++ b/packages/astro-consent/scripts/copy-assets.mjs
@@ -1,0 +1,18 @@
+// Cross-platform asset copy (replaces `mkdir -p && cp`, which is POSIX-only).
+import { mkdirSync, copyFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, '..');
+
+const assets = [
+  ['src/styles/base.css', 'dist/styles/base.css'],
+];
+
+for (const [from, to] of assets) {
+  const src = resolve(pkgRoot, from);
+  const dst = resolve(pkgRoot, to);
+  mkdirSync(dirname(dst), { recursive: true });
+  copyFileSync(src, dst);
+}

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -1,4 +1,5 @@
 import type { ConsentState, SerializableConsentConfig, ConsentAPI } from './types.js';
+import { CONSENT_EVENT, CHANGE_EVENT } from './types.js';
 import {
   readConsent,
   writeConsent,
@@ -14,53 +15,43 @@ import {
   hideBanner,
   showModal,
   hideModal,
+  isModalVisible,
   getModalSelections,
   updateModalToggles,
+  handleModalTabTrap,
 } from './ui.js';
-
-interface ConsentCallbacks {
-  onConsent?: (state: ConsentState) => void;
-  onChange?: (state: ConsentState) => void;
-}
 
 let listenerAttached = false;
 let consentFiredThisSession = false;
 
-function fireCallback(
-  callbacks: ConsentCallbacks,
-  type: 'onConsent' | 'onChange',
-  state: ConsentState,
-): void {
-  const cb = callbacks[type];
-  if (cb) {
-    try {
-      cb(state);
-    } catch (e) {
-      console.error(`[astro-consent] ${type} callback error:`, e);
-    }
-  }
+/**
+ * Dispatches a consent event on `document`. Using events (instead of
+ * functions serialized through the Astro config) avoids the closure problem:
+ * subscribers in user-land `<script>` tags can import modules, call closures,
+ * and reference outer scope — none of which works when a callback is
+ * serialized with `Function.prototype.toString`.
+ */
+function emit(type: typeof CONSENT_EVENT | typeof CHANGE_EVENT, state: ConsentState): void {
+  document.dispatchEvent(new CustomEvent(type, { detail: state }));
 }
 
-export function initConsentManager(
-  config: SerializableConsentConfig,
-  callbacks: ConsentCallbacks,
-): void {
-  // Inject banner + modal DOM (idempotent)
+export function initConsentManager(config: SerializableConsentConfig): void {
+  // Inject banner + modal DOM (idempotent).
   injectUI(config);
 
-  // Check consent state
+  // Check consent state.
   if (needsConsent(config.version)) {
     showBanner();
   } else if (!consentFiredThisSession) {
-    // Fire onConsent once per session (not on every SPA navigation)
+    // Fire the consent event once per session (not on every SPA navigation).
     consentFiredThisSession = true;
     const existing = readConsent();
     if (existing) {
-      fireCallback(callbacks, 'onConsent', existing);
+      emit(CONSENT_EVENT, existing);
     }
   }
 
-  // Attach event delegation (once per page lifecycle)
+  // Attach event delegation (once per page lifecycle).
   if (!listenerAttached) {
     listenerAttached = true;
 
@@ -78,7 +69,7 @@ export function initConsentManager(
           hideBanner();
           hideModal();
           consentFiredThisSession = true;
-          fireCallback(callbacks, 'onConsent', state);
+          emit(CONSENT_EVENT, state);
           break;
         }
 
@@ -89,18 +80,18 @@ export function initConsentManager(
           hideBanner();
           hideModal();
           consentFiredThisSession = true;
-          fireCallback(callbacks, 'onConsent', state);
+          emit(CONSENT_EVENT, state);
           break;
         }
 
         case 'manage': {
           hideBanner();
-          // Sync toggles with current state or defaults
+          // Sync toggles with current state or defaults.
           const current = readConsent();
           if (current) {
             updateModalToggles(current.categories);
           } else {
-            // After reset: show defaults from config
+            // After reset: show defaults from config.
             const defaults: Record<string, boolean> = {};
             for (const [key, cat] of Object.entries(config.categories)) {
               defaults[key] = cat.default;
@@ -118,13 +109,13 @@ export function initConsentManager(
           writeConsent(state);
           hideModal();
           consentFiredThisSession = true;
-          fireCallback(callbacks, isUpdate ? 'onChange' : 'onConsent', state);
+          emit(isUpdate ? CHANGE_EVENT : CONSENT_EVENT, state);
           break;
         }
 
         case 'close-modal': {
           hideModal();
-          // Re-show banner if consent hasn't been given yet
+          // Re-show banner if consent hasn't been given yet.
           if (needsConsent(config.version)) {
             showBanner();
           }
@@ -133,7 +124,7 @@ export function initConsentManager(
       }
     });
 
-    // Close modal on overlay click
+    // Close modal on overlay click.
     document.addEventListener('click', (e) => {
       if ((e.target as HTMLElement).id === 'cc-overlay') {
         hideModal();
@@ -143,21 +134,23 @@ export function initConsentManager(
       }
     });
 
-    // Close modal on Escape key
+    // Keyboard handling: Escape to close, Tab trapped inside modal.
     document.addEventListener('keydown', (e) => {
+      if (!isModalVisible()) return;
+
       if (e.key === 'Escape') {
-        const modal = document.getElementById('cc-modal');
-        if (modal?.classList.contains('cc-visible')) {
-          hideModal();
-          if (needsConsent(config.version)) {
-            showBanner();
-          }
+        hideModal();
+        if (needsConsent(config.version)) {
+          showBanner();
         }
+        return;
       }
+
+      handleModalTabTrap(e);
     });
   }
 
-  // Expose runtime API
+  // Expose runtime API.
   const api: ConsentAPI = {
     get: () => readConsent(),
     set: (categories) => {
@@ -175,7 +168,7 @@ export function initConsentManager(
         categories: merged,
       };
       writeConsent(state);
-      fireCallback(callbacks, 'onChange', state);
+      emit(CHANGE_EVENT, state);
     },
     reset: () => {
       clearConsent();
@@ -203,5 +196,5 @@ export function initConsentManager(
     },
   };
 
-  (window as unknown as Record<string, unknown>).zdenekkureckaConsent = api;
+  window.zdenekkureckaConsent = api;
 }

--- a/packages/astro-consent/src/integration.ts
+++ b/packages/astro-consent/src/integration.ts
@@ -1,6 +1,3 @@
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
 import type { AstroIntegration } from 'astro';
 import type { ConsentConfig, SerializableConsentConfig } from './types.js';
 import { vitePluginConsentConfig } from './virtual-config.js';
@@ -17,36 +14,25 @@ export default function cookieConsent(userConfig: ConsentConfig): AstroIntegrati
       'astro:config:setup': ({ updateConfig, injectScript, logger }) => {
         logger.info('Setting up cookie consent...');
 
-        // 1. Register Vite plugin for virtual modules (config + init entry)
+        // Register the Vite plugin that backs the virtual init module.
         updateConfig({
           vite: {
             plugins: [vitePluginConsentConfig(serializableConfig)],
           },
         });
 
-        // 2. Inject compiled CSS as inline <style> in <head>
-        const thisDir = dirname(fileURLToPath(import.meta.url));
-        const cssPath = resolve(thisDir, 'styles', 'base.css');
-        const css = readFileSync(cssPath, 'utf-8');
-        injectScript('head-inline', `if(!document.getElementById('cc-styles')){const s=document.createElement('style');s.id='cc-styles';s.textContent=${JSON.stringify(css)};document.head.appendChild(s)}`);
+        // Inject the CSS via `page-ssr` so it flows through Astro's normal
+        // CSS extraction pipeline and is emitted as a hashed
+        // <link rel="stylesheet"> in <head>. No inline <style>, CSP-safe.
+        injectScript(
+          'page-ssr',
+          'import "@zdenekkurecka/astro-consent/styles/base.css";',
+        );
 
-        // 3. Inject client-side init module on every page
+        // Inject the client runtime. `injectScript('page', ...)` compiles to
+        // a hashed <script type="module" src="..."> — not inline — so the
+        // integration also works under strict script-src CSP.
         injectScript('page', 'import "virtual:astro-consent/init";');
-
-        // 4. Inject callbacks via head-inline (runs before modules)
-        if (userConfig.onConsent || userConfig.onChange) {
-          const parts: string[] = [];
-          if (userConfig.onConsent) {
-            parts.push(`onConsent: ${userConfig.onConsent.toString()}`);
-          }
-          if (userConfig.onChange) {
-            parts.push(`onChange: ${userConfig.onChange.toString()}`);
-          }
-          injectScript(
-            'head-inline',
-            `window.__astroConsentCallbacks = { ${parts.join(', ')} };`,
-          );
-        }
       },
     },
   };

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -7,8 +7,6 @@ export interface ConsentCategory {
 export interface ConsentConfig {
   version: number;
   categories: Record<string, ConsentCategory>;
-  onConsent?: (state: ConsentState) => void;
-  onChange?: (state: ConsentState) => void;
 }
 
 export interface ConsentState {
@@ -28,4 +26,35 @@ export interface ConsentAPI {
   reset(): void;
   show(): void;
   showPreferences(): void;
+}
+
+/**
+ * Name of the CustomEvent dispatched on `document` once per session after the
+ * user has given consent (or after the integration detects an existing valid
+ * consent record on page load).
+ *
+ * @example
+ *   document.addEventListener('astro-consent:consent', (e) => {
+ *     if (e.detail.categories.analytics) loadAnalytics();
+ *   });
+ */
+export const CONSENT_EVENT = 'astro-consent:consent';
+
+/**
+ * Name of the CustomEvent dispatched on `document` whenever the user updates
+ * their preferences after an initial consent has been given.
+ */
+export const CHANGE_EVENT = 'astro-consent:change';
+
+export type ConsentEvent = CustomEvent<ConsentState>;
+
+declare global {
+  interface DocumentEventMap {
+    'astro-consent:consent': ConsentEvent;
+    'astro-consent:change': ConsentEvent;
+  }
+
+  interface Window {
+    zdenekkureckaConsent?: ConsentAPI;
+  }
 }

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -1,6 +1,12 @@
 import type { SerializableConsentConfig } from './types.js';
 
 const CONTAINER_ID = 'cc-container';
+const MODAL_ID = 'cc-modal';
+const MODAL_TITLE_ID = 'cc-modal-title';
+const OVERLAY_ID = 'cc-overlay';
+const BANNER_ID = 'cc-banner';
+
+let previouslyFocused: HTMLElement | null = null;
 
 function escapeHtml(str: string): string {
   return str
@@ -13,16 +19,16 @@ function escapeHtml(str: string): string {
 
 function createBannerHTML(): string {
   return `
-    <div class="cc-banner" id="cc-banner" role="dialog" aria-label="Cookie consent">
+    <div class="cc-banner" id="${BANNER_ID}" role="region" aria-label="Cookie consent">
       <div class="cc-banner-inner">
         <p class="cc-banner-text">
           We use cookies to enhance your browsing experience, serve personalized content, and analyze our traffic.
           Please choose your cookie preferences.
         </p>
         <div class="cc-banner-actions">
-          <button class="cc-btn cc-btn-primary" data-cc="accept-all">Accept all</button>
-          <button class="cc-btn cc-btn-secondary" data-cc="reject-all">Reject all</button>
-          <button class="cc-btn cc-btn-link" data-cc="manage">Manage preferences</button>
+          <button type="button" class="cc-btn cc-btn-primary" data-cc="accept-all">Accept all</button>
+          <button type="button" class="cc-btn cc-btn-secondary" data-cc="reject-all">Reject all</button>
+          <button type="button" class="cc-btn cc-btn-link" data-cc="manage">Manage preferences</button>
         </div>
       </div>
     </div>`;
@@ -38,17 +44,18 @@ function createCategoryToggle(
   const checked = isEssential || defaultValue ? 'checked' : '';
   const disabled = isEssential ? 'disabled' : '';
   const id = `cc-toggle-${escapeHtml(key)}`;
+  const descId = `${id}-desc`;
 
   return `
     <div class="cc-category">
       <div class="cc-category-header">
         <label class="cc-category-label" for="${id}">${escapeHtml(label)}</label>
         <label class="cc-toggle">
-          <input type="checkbox" id="${id}" data-cc-category="${escapeHtml(key)}" ${checked} ${disabled} />
-          <span class="cc-toggle-slider"></span>
+          <input type="checkbox" id="${id}" data-cc-category="${escapeHtml(key)}" aria-describedby="${descId}" ${checked} ${disabled} />
+          <span class="cc-toggle-slider" aria-hidden="true"></span>
         </label>
       </div>
-      <p class="cc-category-description">${escapeHtml(description)}</p>
+      <p class="cc-category-description" id="${descId}">${escapeHtml(description)}</p>
     </div>`;
 }
 
@@ -66,21 +73,29 @@ function createModalHTML(config: SerializableConsentConfig): string {
     .join('');
 
   return `
-    <div class="cc-overlay" id="cc-overlay" aria-hidden="true"></div>
-    <div class="cc-modal" id="cc-modal" role="dialog" aria-label="Cookie preferences" aria-hidden="true">
+    <div class="cc-overlay" id="${OVERLAY_ID}" aria-hidden="true"></div>
+    <div
+      class="cc-modal"
+      id="${MODAL_ID}"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="${MODAL_TITLE_ID}"
+      aria-hidden="true"
+      tabindex="-1"
+    >
       <div class="cc-modal-inner">
         <div class="cc-modal-header">
-          <h2 class="cc-modal-title">Cookie preferences</h2>
-          <button class="cc-modal-close" data-cc="close-modal" aria-label="Close">&times;</button>
+          <h2 class="cc-modal-title" id="${MODAL_TITLE_ID}">Cookie preferences</h2>
+          <button type="button" class="cc-modal-close" data-cc="close-modal" aria-label="Close preferences">&times;</button>
         </div>
         <div class="cc-modal-body">
           ${essentialToggle}
           ${categoryToggles}
         </div>
         <div class="cc-modal-footer">
-          <button class="cc-btn cc-btn-primary" data-cc="modal-accept-all">Accept all</button>
-          <button class="cc-btn cc-btn-secondary" data-cc="modal-reject-all">Reject all</button>
-          <button class="cc-btn cc-btn-primary" data-cc="save-preferences">Save preferences</button>
+          <button type="button" class="cc-btn cc-btn-primary" data-cc="modal-accept-all">Accept all</button>
+          <button type="button" class="cc-btn cc-btn-secondary" data-cc="modal-reject-all">Reject all</button>
+          <button type="button" class="cc-btn cc-btn-primary" data-cc="save-preferences">Save preferences</button>
         </div>
       </div>
     </div>`;
@@ -96,29 +111,104 @@ export function injectUI(config: SerializableConsentConfig): void {
 }
 
 export function showBanner(): void {
-  document.getElementById('cc-banner')?.classList.add('cc-visible');
+  document.getElementById(BANNER_ID)?.classList.add('cc-visible');
 }
 
 export function hideBanner(): void {
-  document.getElementById('cc-banner')?.classList.remove('cc-visible');
+  document.getElementById(BANNER_ID)?.classList.remove('cc-visible');
+}
+
+/**
+ * Returns focusable descendants of `container` in tab order, skipping elements
+ * that are disabled, hidden (`display: none` / `visibility: hidden`) or
+ * explicitly removed from the tab order with `tabindex="-1"`.
+ */
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  const selector = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled]):not([type="hidden"])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',');
+
+  const nodes = Array.from(container.querySelectorAll<HTMLElement>(selector));
+  return nodes.filter((el) => {
+    if (el.hasAttribute('inert')) return false;
+    // offsetParent is null for display:none; doesn't cover visibility:hidden,
+    // but our modal doesn't use that so this is sufficient.
+    if (el.offsetParent === null && el.tagName !== 'BODY') return false;
+    return true;
+  });
+}
+
+/**
+ * Traps Tab/Shift+Tab inside the modal when it's visible. No-op otherwise, so
+ * it's safe to attach once for the lifetime of the page.
+ */
+export function handleModalTabTrap(e: KeyboardEvent): void {
+  if (e.key !== 'Tab') return;
+  const modal = document.getElementById(MODAL_ID);
+  if (!modal || !modal.classList.contains('cc-visible')) return;
+
+  const focusable = getFocusableElements(modal);
+  if (focusable.length === 0) {
+    // Nothing focusable inside — keep focus on the modal container itself.
+    e.preventDefault();
+    modal.focus();
+    return;
+  }
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement as HTMLElement | null;
+
+  // If focus has escaped the modal entirely, pull it back.
+  if (!active || !modal.contains(active)) {
+    e.preventDefault();
+    (e.shiftKey ? last : first).focus();
+    return;
+  }
+
+  if (e.shiftKey && active === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && active === last) {
+    e.preventDefault();
+    first.focus();
+  }
 }
 
 export function showModal(): void {
-  const modal = document.getElementById('cc-modal');
-  const overlay = document.getElementById('cc-overlay');
-  if (modal) {
-    modal.classList.add('cc-visible');
-    modal.setAttribute('aria-hidden', 'false');
-  }
+  const modal = document.getElementById(MODAL_ID);
+  const overlay = document.getElementById(OVERLAY_ID);
+  if (!modal) return;
+
+  // Remember who had focus so we can restore it on close.
+  const active = document.activeElement;
+  previouslyFocused = active instanceof HTMLElement ? active : null;
+
+  modal.classList.add('cc-visible');
+  modal.setAttribute('aria-hidden', 'false');
   if (overlay) {
     overlay.classList.add('cc-visible');
     overlay.setAttribute('aria-hidden', 'false');
   }
+
+  // Move focus into the modal on the next frame so CSS transitions don't
+  // steal the initial focus.
+  requestAnimationFrame(() => {
+    const focusable = getFocusableElements(modal);
+    // Prefer the first interactive control (close button is first in DOM);
+    // fall back to the modal container, which is tabindex="-1".
+    (focusable[0] ?? modal).focus();
+  });
 }
 
 export function hideModal(): void {
-  const modal = document.getElementById('cc-modal');
-  const overlay = document.getElementById('cc-overlay');
+  const modal = document.getElementById(MODAL_ID);
+  const overlay = document.getElementById(OVERLAY_ID);
   if (modal) {
     modal.classList.remove('cc-visible');
     modal.setAttribute('aria-hidden', 'true');
@@ -127,6 +217,22 @@ export function hideModal(): void {
     overlay.classList.remove('cc-visible');
     overlay.setAttribute('aria-hidden', 'true');
   }
+
+  // Restore focus to the element that triggered the modal, if it's still
+  // connected to the DOM and focusable.
+  const toFocus = previouslyFocused;
+  previouslyFocused = null;
+  if (toFocus && toFocus.isConnected) {
+    try {
+      toFocus.focus();
+    } catch {
+      /* ignore — e.g. element became non-focusable */
+    }
+  }
+}
+
+export function isModalVisible(): boolean {
+  return document.getElementById(MODAL_ID)?.classList.contains('cc-visible') ?? false;
 }
 
 export function updateModalToggles(categories: Record<string, boolean>): void {

--- a/packages/astro-consent/src/virtual-config.ts
+++ b/packages/astro-consent/src/virtual-config.ts
@@ -1,5 +1,3 @@
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
 import type { SerializableConsentConfig } from './types.js';
 
 interface VitePlugin {
@@ -13,14 +11,13 @@ const VIRTUAL_INIT = 'virtual:astro-consent/init';
 const RESOLVED_CONFIG = '\0' + VIRTUAL_CONFIG;
 const RESOLVED_INIT = '\0' + VIRTUAL_INIT;
 
-function normalizePath(p: string): string {
-  return p.replace(/\\/g, '/');
-}
+// Import the client via the package's own bare specifier so Vite resolves it
+// through normal package resolution. This keeps the virtual module
+// cross-platform (no absolute filesystem paths embedded as import strings)
+// and decoupled from the on-disk dist/ layout.
+const CLIENT_SPECIFIER = '@zdenekkurecka/astro-consent/client';
 
 export function vitePluginConsentConfig(config: SerializableConsentConfig): VitePlugin {
-  // Resolve paths relative to this file's location in dist/
-  const thisDir = dirname(fileURLToPath(import.meta.url));
-  const clientPath = normalizePath(resolve(thisDir, 'client.js'));
   return {
     name: 'vite-plugin-astro-consent',
 
@@ -37,7 +34,7 @@ export function vitePluginConsentConfig(config: SerializableConsentConfig): Vite
       if (id === RESOLVED_INIT) {
         return [
           `import config from '${VIRTUAL_CONFIG}';`,
-          `import { initConsentManager } from '${clientPath}';`,
+          `import { initConsentManager } from '${CLIENT_SPECIFIER}';`,
           ``,
           `const callbacks = typeof window !== 'undefined' ? (window.__astroConsentCallbacks || {}) : {};`,
           ``,

--- a/packages/astro-consent/src/virtual-config.ts
+++ b/packages/astro-consent/src/virtual-config.ts
@@ -14,7 +14,8 @@ const RESOLVED_INIT = '\0' + VIRTUAL_INIT;
 // Import the client via the package's own bare specifier so Vite resolves it
 // through normal package resolution. This keeps the virtual module
 // cross-platform (no absolute filesystem paths embedded as import strings)
-// and decoupled from the on-disk dist/ layout.
+// and decoupled from the on-disk dist/ layout. The CSS is injected
+// separately by the integration via `injectScript('page-ssr', ...)`.
 const CLIENT_SPECIFIER = '@zdenekkurecka/astro-consent/client';
 
 export function vitePluginConsentConfig(config: SerializableConsentConfig): VitePlugin {
@@ -36,10 +37,8 @@ export function vitePluginConsentConfig(config: SerializableConsentConfig): Vite
           `import config from '${VIRTUAL_CONFIG}';`,
           `import { initConsentManager } from '${CLIENT_SPECIFIER}';`,
           ``,
-          `const callbacks = typeof window !== 'undefined' ? (window.__astroConsentCallbacks || {}) : {};`,
-          ``,
           `function init() {`,
-          `  initConsentManager(config, callbacks);`,
+          `  initConsentManager(config);`,
           `}`,
           ``,
           `document.addEventListener('astro:page-load', init);`,

--- a/packages/astro-consent/tsconfig.build.json
+++ b/packages/astro-consent/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "declarationMap": false
+  }
+}

--- a/playground/astro.config.mjs
+++ b/playground/astro.config.mjs
@@ -17,12 +17,6 @@ export default defineConfig({
           default: false,
         },
       },
-      onConsent: (state) => {
-        console.log('[playground] Consent given:', state);
-      },
-      onChange: (state) => {
-        console.log('[playground] Consent changed:', state);
-      },
     }),
   ],
 });

--- a/playground/src/pages/index.astro
+++ b/playground/src/pages/index.astro
@@ -23,26 +23,38 @@ import Layout from '../layouts/Layout.astro';
   <script>
     function refreshState() {
       const el = document.getElementById('state');
-      const consent = (window as any).zdenekkureckaConsent;
+      const consent = window.zdenekkureckaConsent;
       if (el && consent) {
         const state = consent.get();
         el.textContent = state ? JSON.stringify(state, null, 2) : 'No consent data yet.';
       }
     }
 
+    // Subscribe to consent events. Unlike `.toString()`-serialized callbacks,
+    // these listeners run in the page's normal module scope and can close
+    // over imports, outer variables, etc.
+    document.addEventListener('astro-consent:consent', (e) => {
+      console.log('[playground] Consent given:', e.detail);
+      refreshState();
+    });
+    document.addEventListener('astro-consent:change', (e) => {
+      console.log('[playground] Consent changed:', e.detail);
+      refreshState();
+    });
+
     document.addEventListener('astro:page-load', () => {
       refreshState();
 
       document.getElementById('btn-show')?.addEventListener('click', () => {
-        (window as any).zdenekkureckaConsent?.show();
+        window.zdenekkureckaConsent?.show();
       });
 
       document.getElementById('btn-prefs')?.addEventListener('click', () => {
-        (window as any).zdenekkureckaConsent?.showPreferences();
+        window.zdenekkureckaConsent?.showPreferences();
       });
 
       document.getElementById('btn-reset')?.addEventListener('click', () => {
-        (window as any).zdenekkureckaConsent?.reset();
+        window.zdenekkureckaConsent?.reset();
         refreshState();
       });
 


### PR DESCRIPTION
## Summary

Closes the compliance- and publishing-blocker items before the first `0.1.0` release of `@zdenekkurecka/astro-consent`. Scoped to: (1) making the package safe to publish, (2) removing the accessibility / closure / CSP footguns that would generate audit findings or angry issues, (3) wiring up a Trusted Publishing release workflow.

Nothing here touches the visual UI shape — that's the next task.

## Publishing hardening (`packages/astro-consent/package.json`, new files)

- `prepublishOnly: "pnpm run build"` — a fresh clone could previously ship an empty `dist/` because `dist` is in the root `.gitignore`. The build is now enforced before publish.
- Added `license: "MIT"` + copied `LICENSE` into the package dir (root `LICENSE` wasn't in the tarball before).
- Added a real `packages/astro-consent/README.md` (the npmjs.com page would have been blank).
- Full metadata: `description`, `keywords`, `author`, `homepage`, `bugs`, `repository` with `directory: "packages/astro-consent"` so the npm "Repository" link points to the subfolder.
- `exports` map now includes a `types` condition for `nodenext`/`bundler` resolution, a `./client` subpath export, and a `./styles` / `./styles/base.css` / `./package.json` export.
- `sideEffects: ["**/*.css"]` so bundlers tree-shake JS but preserve CSS imports.
- `engines: { node: ">=18.17.0" }` matches the Astro 5/6 baseline.
- Split `tsconfig.build.json` disables `sourceMap` + `declarationMap` for publish so we don't ship `.map` files that reference `../src/*.ts` sources that aren't in the tarball.
- Replaced the POSIX-only `mkdir -p && cp` build step with a cross-platform `scripts/copy-assets.mjs`.
- Added a `clean` prebuild so stale files from renamed/deleted sources can't leak into `dist/`.

Validated end-to-end with `publint` (`All good!`), `@arethetypeswrong/cli`, and a full `npm pack --dry-run` inspection (18 files, 11.3 kB, includes LICENSE + README).

## Modal accessibility (`src/ui.ts`, `src/client.ts`)

- `role="dialog"` + `aria-modal="true"` + `aria-labelledby` pointing at a visible `<h2 id="cc-modal-title">`.
- `tabindex="-1"` on the dialog container so it can receive programmatic focus.
- `showModal()` stores the previously-focused element; `requestAnimationFrame` then moves focus to the first interactive control.
- `Tab` / `Shift+Tab` is trapped inside the modal; if focus escapes (browser extensions, etc.) it's pulled back in.
- `Escape`, overlay click, save, accept, reject, and close all restore focus to the original trigger.
- Banner demoted from `role="dialog"` to `role="region"` — it never blocks anything and was mis-labelled.
- All `<button>`s gained `type="button"` so they can't accidentally submit ambient forms.
- Category toggles gained `aria-describedby` pointing at the description paragraph.

## Typed `CustomEvent` callbacks (removes the closure footgun)

Dropped `onConsent` / `onChange` from `ConsentConfig`. The old design serialized user functions via `Function.prototype.toString()` and re-injected them as `head-inline`, which **silently breaks** any callback that references an import, a closure, or any module-scope symbol.

Replaced with `document`-level `CustomEvent`s:

```ts
document.addEventListener('astro-consent:consent', (e) => {
  if (e.detail.categories.analytics) loadAnalytics();
});
document.addEventListener('astro-consent:change', (e) => {
  console.log('consent updated', e.detail);
});
```

`src/types.ts` augments `DocumentEventMap` and `Window`, so `e.detail: ConsentState` and `window.zdenekkureckaConsent?.show()` are fully typed in consumer code with **zero casts**. Constants `CONSENT_EVENT` / `CHANGE_EVENT` are also exported.

## Strict CSP support (`src/integration.ts`)

Dropped all `injectScript('head-inline', ...)` calls — both the inline `<style>` and the `window.__astroConsentCallbacks = {...}` shim are gone. The integration now only uses:

- `injectScript('page', 'import "virtual:astro-consent/init";')` → Astro emits as `<script type="module" src="/_astro/page.<hash>.js">`
- `injectScript('page-ssr', 'import "@zdenekkurecka/astro-consent/styles/base.css";')` → Astro routes through its CSS extractor and emits as `<link rel="stylesheet" href="/_astro/Layout.<hash>.css">`

Verified in the built playground HTML. The integration now works under:

```
Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self';
```

with no `'unsafe-inline'` required.

**Gotcha:** my first attempt imported the CSS from *inside* the `'page'`-stage virtual module. Astro/Vite silently dropped it — the `'page'`-stage script graph doesn't feed Astro's CSS extractor. The `'page-ssr'` stage does. Documented in the commit message so it doesn't regress.

## Release workflow — Trusted Publishing (`.github/workflows/publish.yml`)

OIDC-based Trusted Publishing, not a classic automation token (npm flags those as security risks):

- **No stored secrets.** At publish time, GitHub issues a short-lived OIDC token, npm exchanges it for a one-shot registry credential, and the tarball is published with a provenance attestation (`"Built and signed on GitHub Actions"` badge on npm).
- `permissions: id-token: write` grants the runner the OIDC token.
- Node 22, explicit `npm install -g npm@latest` before publish (Trusted Publishing + `--provenance` needs npm >= 11.5.1; Node 22 ships npm 10.x).
- Triggers: tag push matching `astro-consent-v*` **or** `workflow_dispatch` with a `dry-run` toggle.
- Pre-publish steps: tag ↔ `package.json` version guard, `publint`, and a full playground build as a smoke test. Any failure aborts the publish.
- Publish step is `npm publish --provenance --access public` from `working-directory: packages/astro-consent`.

Intentionally **not** adding `"provenance": true` to `publishConfig` — that would break the first manual publish and any emergency local republish. The flag is passed per-invocation in the workflow instead.

## What still needs to happen outside this PR

1. **Manual first publish** of `0.1.0` from a laptop (`npm login && cd packages/astro-consent && npm publish`) to create the package on npm. Trusted Publishing can't be configured against a package that doesn't exist yet.
2. On npmjs.com → package → Access → **Trusted Publisher** → GitHub Actions, configure: org `zdenekkurecka`, repo `astro-consent`, workflow filename `publish.yml`.
3. From `0.1.1` onward, releases go through the workflow: bump version → tag `astro-consent-v0.1.1` → push tag.

## Test plan

- [x] `pnpm --filter @zdenekkurecka/astro-consent build` — clean, no source maps emitted
- [x] `pnpm --filter playground build` — 2 pages, CSS in hashed `<link>`, JS in hashed `<script src>`, no inline `<style>`/`<script>` from the package
- [x] `pnpm --filter playground dev` — integration log fires, Vite connects, no errors
- [x] `publint` — `All good!`
- [x] `@arethetypeswrong/cli` — `.` + `./client` resolve correctly for ESM + bundler (expected `node10` failures on subpath exports documented)
- [x] `npm pack --dry-run` — 18 files, includes LICENSE + README, no `.map` files
- [x] `npm publish --dry-run` (local) — tarball simulates publish cleanly
- [x] Tag ↔ version guard verified locally (positive and negative cases)
- [x] Grepped built bundle to confirm: `aria-modal="true"` present, `CustomEvent` dispatched, 6× `.focus()` calls (focus trap + restore + initial)
- [ ] Dry-run `workflow_dispatch` on the Actions tab once `NPM_TOKEN` → Trusted Publishing is configured on npmjs.com
- [ ] First manual `0.1.0` publish from laptop
- [ ] First workflow-driven `0.1.1` publish to validate the OIDC handshake end-to-end

https://claude.ai/code/session_01NWqbtkSBNXVLHeKYCsTdPE