### PR TITLE
Fix consent manager initialization for non-View Transitions sites

### DIFF
--- a/packages/astro-consent/README.md
+++ b/packages/astro-consent/README.md
@@ -5,7 +5,10 @@ banner, a preferences modal, a small runtime API, and category-based consent
 state persisted in `localStorage`.
 
 - Zero-dependency runtime
-- Works with Astro's View Transitions / SPA routing (`astro:page-load`)
+- Works on standard Astro sites **and** with View Transitions / SPA routing —
+  the runtime initializes on `DOMContentLoaded` (or immediately if the DOM is
+  already parsed) and re-runs on `astro:page-load` when `<ClientRouter />` is
+  active
 - Versioned consent — bump `version` to re-prompt users
 - Typed config, runtime API, and typed `document` event map
 - Accessible modal — `role="dialog"` / `aria-modal`, focus trap, focus
@@ -71,6 +74,12 @@ The integration:
 3. Injects the stylesheet via `injectScript('page-ssr', ...)` which routes
    the CSS through Astro's normal CSS pipeline, emitting a hashed
    `<link rel="stylesheet">` — never inline.
+
+The injected runtime bootstraps itself on `DOMContentLoaded` (or synchronously
+if the document is already parsed) **and** on `astro:page-load`, so it works
+identically on plain Astro sites and on sites using `<ClientRouter />` for
+View Transitions. Initialization is idempotent, so subsequent SPA navigations
+only re-attach per-page state.
 
 ### Reacting to consent changes
 

--- a/packages/astro-consent/package.json
+++ b/packages/astro-consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zdenekkurecka/astro-consent",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Astro integration for GDPR/ePrivacy-friendly cookie consent: banner, preferences modal, runtime API, category-based consent state, strict-CSP safe, works with or without View Transitions.",
   "keywords": [
     "astro",

--- a/packages/astro-consent/package.json
+++ b/packages/astro-consent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zdenekkurecka/astro-consent",
   "version": "0.1.0",
-  "description": "Astro integration for GDPR/ePrivacy-friendly cookie consent: banner, preferences modal, runtime API and category-based consent state.",
+  "description": "Astro integration for GDPR/ePrivacy-friendly cookie consent: banner, preferences modal, runtime API, category-based consent state, strict-CSP safe, works with or without View Transitions.",
   "keywords": [
     "astro",
     "astro-integration",

--- a/packages/astro-consent/src/virtual-config.ts
+++ b/packages/astro-consent/src/virtual-config.ts
@@ -41,7 +41,18 @@ export function vitePluginConsentConfig(config: SerializableConsentConfig): Vite
           `  initConsentManager(config);`,
           `}`,
           ``,
+          `// Fires on every View Transitions navigation (and initial load when VT is enabled).`,
           `document.addEventListener('astro:page-load', init);`,
+          ``,
+          `// Fallback for sites without View Transitions: astro:page-load never fires there,`,
+          `// so we also listen for DOMContentLoaded (or run immediately if the DOM is already`,
+          `// ready). initConsentManager is idempotent (listenerAttached / consentFiredThisSession`,
+          `// guards in client.ts), so double-firing on VT-enabled sites is safe.`,
+          `if (document.readyState === 'loading') {`,
+          `  document.addEventListener('DOMContentLoaded', init, { once: true });`,
+          `} else {`,
+          `  init();`,
+          `}`,
         ].join('\n');
       }
     },


### PR DESCRIPTION
## Summary
This PR fixes the consent manager runtime to properly initialize on standard Astro sites that don't use View Transitions. Previously, the runtime only listened for `astro:page-load`, which never fires on non-VT sites, leaving the consent manager uninitialized.

## Key Changes
- **Runtime initialization**: Added fallback initialization logic that:
  - Listens for `DOMContentLoaded` on sites without View Transitions
  - Runs synchronously if the DOM is already parsed
  - Maintains `astro:page-load` listener for VT-enabled sites
  - Leverages idempotent initialization (existing guards in `client.ts`) to safely handle both initialization paths

- **Documentation**: Updated README to clarify that the integration works on both standard Astro sites and sites using `<ClientRouter />` for View Transitions

- **Package metadata**: Bumped version to 0.1.1 and enhanced description to highlight View Transitions compatibility and strict-CSP safety

## Implementation Details
The injected runtime now:
1. Always registers the `astro:page-load` listener (for VT sites)
2. Checks `document.readyState` to determine if the DOM is still loading
3. If loading, attaches a one-time `DOMContentLoaded` listener
4. If already parsed, calls `init()` immediately

This ensures the consent manager initializes exactly once on all site types, with subsequent SPA navigations (on VT sites) only re-attaching per-page state.

https://claude.ai/code/session_019FQixmk5JTXi1E8KSB9XGQ