### PR TITLE
ci: fix publish workflow — use Node 24 for Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,13 +70,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           # npm Trusted Publishing + provenance requires a reasonably recent
-          # npm CLI (>= 11.5.1). Node 22 ships npm 10.x, so we upgrade npm
-          # explicitly below.
-          node-version: 22
+          # npm CLI (>= 11.5.1). Node 24 (LTS "Krypton") ships with npm 11.x,
+          # so we get a compatible npm out of the box — no self-upgrade step
+          # needed. Upgrading npm in-place on Node 22 (which ships npm 10.x)
+          # is unreliable on GitHub Actions runners: the 10 → 11 self-upgrade
+          # can leave the running process with a half-replaced node_modules
+          # tree and fail with `Cannot find module 'promise-retry'`.
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm to a version with Trusted Publishing support
-        run: npm install --global npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Bugfix

The `astro-consent-v0.1.1` publish workflow run (24313553483) failed, so `0.1.1` never made it to npm — only `0.1.0` is currently published on the registry.

### What went wrong

The failing step was **"Upgrade npm to a version with Trusted Publishing support"**:

```
npm install --global npm@latest
→ npm error code MODULE_NOT_FOUND
→ npm error Cannot find module 'promise-retry'
```

npm Trusted Publishing + provenance requires npm ≥ 11.5.1, but Node 22 (the version the workflow was pinned to) ships with npm 10.9.7. The workflow tried to self-upgrade npm at runtime with `npm install -g npm@latest`, and that's where it blew up.

Root cause of the upgrade failure: upgrading npm in-place on a running Node 22 process is unreliable on GitHub Actions runners. The 10 → 11 self-upgrade can leave the running process with a half-replaced `node_modules` tree, so `require('promise-retry')` fails mid-install. Reproduced locally with the same symptom; `--force` does not help.

Because step 5 failed, every subsequent step (build, publint, playground smoke test, publish) was skipped.

### Fix

Bump `node-version: 22` → `node-version: 24` in `.github/workflows/publish.yml` and delete the fragile "Upgrade npm" step entirely.

Node 24 (LTS "Krypton", current v24.14.1) ships with **npm 11.11.0** out of the box, which already satisfies the ≥ 11.5.1 requirement for Trusted Publishing + provenance. No self-upgrade step needed.

Package `engines` is `>=18.17.0`, so Node 24 remains compatible with the library's stated support matrix.

### Follow-up to actually publish 0.1.1

After this merges to `main`, re-trigger the publish workflow either by:
- deleting and re-pushing the `astro-consent-v0.1.1` tag, or
- running the workflow manually from the Actions tab (`workflow_dispatch`).

## Test plan

- [ ] Merge to `main`
- [ ] Re-run publish workflow for `astro-consent-v0.1.1`
- [ ] Verify `0.1.1` appears on https://www.npmjs.com/package/@zdenekkurecka/astro-consent
- [ ] Confirm the npm page shows the "Built and signed on GitHub Actions" provenance badge
