### PR TITLE
Release 0.1.2: cookie policy link + docs & DX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ they force you to serialize your tracker callbacks into a JSON config.
   declare), plus an always-on implicit `essential` category
 - **Versioned consent** — bump a number to re-prompt every user
 - **Typed** config, runtime API, and `document` event map
+- **Optional cookie policy link** surfaced in both banner and preferences modal
 - **Accessible modal**: `role="dialog"` / `aria-modal`, focus trap, focus
   restoration, `Escape` to close, click-outside to dismiss
 - **Strict-CSP safe**: no inline `<script>`, no inline `<style>`
@@ -136,7 +137,38 @@ interface ConsentConfig {
     description: string;
     default: boolean;
   }>;
+
+  /**
+   * Optional link to your cookie / privacy policy. When provided, a small
+   * link is rendered inside the banner and inside the preferences modal.
+   * Only `http(s)://` URLs and same-origin paths (`/…`, `#…`, `?…`) are
+   * accepted — other schemes (e.g. `javascript:`) are ignored.
+   */
+  cookiePolicy?: {
+    url: string;
+    /** Defaults to `"Cookie Policy"`. */
+    label?: string;
+  };
 }
+```
+
+Example with a cookie policy link:
+
+```js
+cookieConsent({
+  version: 1,
+  cookiePolicy: {
+    url: '/legal/cookies',
+    label: 'Cookie Policy',
+  },
+  categories: {
+    analytics: {
+      label: 'Analytics',
+      description: 'Help us understand how visitors use the site.',
+      default: false,
+    },
+  },
+});
 ```
 
 Under the hood, the integration:

--- a/packages/astro-consent/package.json
+++ b/packages/astro-consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zdenekkurecka/astro-consent",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Astro integration for GDPR/ePrivacy-friendly cookie consent: banner, preferences modal, runtime API, category-based consent state, strict-CSP safe, works with or without View Transitions.",
   "keywords": [
     "astro",

--- a/packages/astro-consent/src/integration.ts
+++ b/packages/astro-consent/src/integration.ts
@@ -6,6 +6,7 @@ export default function cookieConsent(userConfig: ConsentConfig): AstroIntegrati
   const serializableConfig: SerializableConsentConfig = {
     version: userConfig.version,
     categories: userConfig.categories,
+    cookiePolicy: userConfig.cookiePolicy,
   };
 
   return {

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -294,10 +294,34 @@
   color: var(--cc-text);
 }
 
+/* ── Policy link ────────────────────────────────────────── */
+
+.cc-policy-link {
+  display: inline-block;
+  font-size: 0.8125rem;
+  color: var(--cc-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.cc-policy-link:hover {
+  color: var(--cc-primary-hover);
+}
+
+.cc-modal-policy-link {
+  margin-top: 0.75rem;
+  color: var(--cc-text-muted);
+}
+
+.cc-modal-policy-link:hover {
+  color: var(--cc-text);
+}
+
 /* ── Focus styles ───────────────────────────────────────── */
 
 .cc-btn:focus-visible,
 .cc-modal-close:focus-visible,
+.cc-policy-link:focus-visible,
 .cc-toggle input:focus-visible + .cc-toggle-slider {
   outline: 2px solid var(--cc-primary);
   outline-offset: 2px;

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -4,9 +4,15 @@ export interface ConsentCategory {
   default: boolean;
 }
 
+export interface CookiePolicyLink {
+  url: string;
+  label?: string;
+}
+
 export interface ConsentConfig {
   version: number;
   categories: Record<string, ConsentCategory>;
+  cookiePolicy?: CookiePolicyLink;
 }
 
 export interface ConsentState {
@@ -18,6 +24,7 @@ export interface ConsentState {
 export interface SerializableConsentConfig {
   version: number;
   categories: Record<string, ConsentCategory>;
+  cookiePolicy?: CookiePolicyLink;
 }
 
 export interface ConsentAPI {

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -17,13 +17,38 @@ function escapeHtml(str: string): string {
     .replace(/'/g, '&#39;');
 }
 
-function createBannerHTML(): string {
+/**
+ * Only allow http(s) absolute URLs or same-origin paths — blocks
+ * `javascript:` and other dangerous schemes that could execute on click.
+ */
+function sanitizeUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  if (trimmed.startsWith('/') || trimmed.startsWith('#') || trimmed.startsWith('?')) return trimmed;
+  return null;
+}
+
+function createPolicyLinkHTML(
+  cookiePolicy: SerializableConsentConfig['cookiePolicy'],
+  className: string,
+): string {
+  if (!cookiePolicy) return '';
+  const safeUrl = sanitizeUrl(cookiePolicy.url);
+  if (!safeUrl) return '';
+  const label = cookiePolicy.label ?? 'Cookie Policy';
+  return `<a class="${className}" href="${escapeHtml(safeUrl)}" data-cc="policy-link">${escapeHtml(label)}</a>`;
+}
+
+function createBannerHTML(config: SerializableConsentConfig): string {
+  const policyLink = createPolicyLinkHTML(config.cookiePolicy, 'cc-policy-link');
   return `
     <div class="cc-banner" id="${BANNER_ID}" role="region" aria-label="Cookie consent">
       <div class="cc-banner-inner">
         <p class="cc-banner-text">
           We use cookies to enhance your browsing experience, serve personalized content, and analyze our traffic.
           Please choose your cookie preferences.
+          ${policyLink}
         </p>
         <div class="cc-banner-actions">
           <button type="button" class="cc-btn cc-btn-primary" data-cc="accept-all">Accept all</button>
@@ -72,6 +97,8 @@ function createModalHTML(config: SerializableConsentConfig): string {
     .map(([key, cat]) => createCategoryToggle(key, cat.label, cat.description, false, cat.default))
     .join('');
 
+  const policyLink = createPolicyLinkHTML(config.cookiePolicy, 'cc-policy-link cc-modal-policy-link');
+
   return `
     <div class="cc-overlay" id="${OVERLAY_ID}" aria-hidden="true"></div>
     <div
@@ -91,6 +118,7 @@ function createModalHTML(config: SerializableConsentConfig): string {
         <div class="cc-modal-body">
           ${essentialToggle}
           ${categoryToggles}
+          ${policyLink}
         </div>
         <div class="cc-modal-footer">
           <button type="button" class="cc-btn cc-btn-primary" data-cc="modal-accept-all">Accept all</button>
@@ -106,7 +134,7 @@ export function injectUI(config: SerializableConsentConfig): void {
 
   const container = document.createElement('div');
   container.id = CONTAINER_ID;
-  container.innerHTML = createBannerHTML() + createModalHTML(config);
+  container.innerHTML = createBannerHTML(config) + createModalHTML(config);
   document.body.appendChild(container);
 }
 

--- a/playground/astro.config.mjs
+++ b/playground/astro.config.mjs
@@ -5,6 +5,10 @@ export default defineConfig({
   integrations: [
     cookieConsent({
       version: 1,
+      cookiePolicy: {
+        url: '/cookie-policy',
+        label: 'Cookie Policy',
+      },
       categories: {
         analytics: {
           label: 'Analytics',


### PR DESCRIPTION
## Summary

Rolls up everything on `dev` since the `0.1.1` tag into a `0.1.2` release.

### New feature — optional Cookie Policy link
- New `cookiePolicy?: { url: string; label?: string }` option on `ConsentConfig`. When set, a small link is rendered inside both the banner text and the preferences modal body.
- URL allowlist: only `http(s)://` absolute URLs and same-origin paths (`/…`, `#…`, `?…`) are accepted — `javascript:` and other unsafe schemes are silently dropped.
- Label defaults to `"Cookie Policy"`.
- Styled via new `.cc-policy-link` / `.cc-modal-policy-link` classes with focus-visible support.
- Playground wired with `/cookie-policy` for local smoke testing.

### Styling
- `feat(styles)`: token defaults are now scoped to `:where(:root)` (zero specificity) so consumers can theme the UI by simply redeclaring CSS variables without `!important`.

### Docs
- Root `README.md` is now the single source of truth for both the repo and the published package — `scripts/copy-assets.mjs` mirrors `README.md` and `LICENSE` into the package on build.
- README fleshed out with a proper GitHub-facing intro, features list, quick start, configuration reference (now including `cookiePolicy`), how-tos (reacting to events, gating 3rd-party scripts, theming, strict-CSP notes), runtime API, events, accessibility notes, and repo layout.
- `.gitignore` cleanup.

### Release
- `chore(release): 0.1.2` — version bump on `@zdenekkurecka/astro-consent`.

## Test plan

- [ ] `pnpm --filter @zdenekkurecka/astro-consent build` succeeds
- [ ] Playground: `pnpm --filter playground dev`, clear `localStorage`, reload → banner shows "Cookie Policy" link; click "Manage preferences" → modal also shows the link
- [ ] Policy link with `url: 'javascript:alert(1)'` is rejected (no link rendered)
- [ ] Keyboard: Tab into the link, focus ring visible; link is part of the modal focus trap
- [ ] Theming: overriding `--cc-primary` on `:root` takes effect without `!important`
- [ ] Published README on npm matches the root `README.md` after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)