### PR TITLE
fix: a11y, API, and delegation bugs (#12, #13, #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,18 @@ interface ConsentAPI {
   /** Returns the currently stored consent state, or `null` if none. */
   get(): ConsentState | null;
 
-  /** Merge a partial category map into the current state and persist it. */
+  /**
+   * Merge a partial category map into the current state and persist it.
+   *
+   * If no consent has been recorded yet (first-time visitor who has not
+   * interacted with the banner), this seeds an initial consent record from
+   * the config defaults, hides the banner, and dispatches
+   * `astro-consent:consent`. Subsequent calls merge into the existing state
+   * and dispatch `astro-consent:change` instead.
+   *
+   * The `essential` category is always forced to `true` and cannot be
+   * disabled through this method.
+   */
   set(categories: Partial<Record<string, boolean>>): void;
 
   /** Clear the stored consent and re-show the banner. */
@@ -367,7 +378,9 @@ Example:
 // Read current state
 const state = window.zdenekkureckaConsent?.get();
 
-// Programmatically update
+// Programmatically update. Safe to call before the user has interacted
+// with the banner — the missing categories fall back to your config
+// defaults and an initial consent record is written.
 window.zdenekkureckaConsent?.set({ analytics: true });
 
 // Re-open the preferences modal (e.g. from a "Cookie settings" footer link)
@@ -396,6 +409,9 @@ autocompletion on `e.detail.categories`.
 - `Tab` / `Shift+Tab` is trapped inside the modal while it's open.
 - `Escape` closes the modal and returns focus to the trigger.
 - Clicking the overlay closes the modal; the overlay itself is `aria-hidden`.
+- Banner and modal both toggle `aria-hidden` in lockstep with their
+  visibility, so screen readers don't announce them while they are
+  visually hidden.
 - All buttons have `type="button"` so they never submit ambient forms.
 
 ## Repository layout

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -121,6 +121,15 @@ export function initConsentManager(config: SerializableConsentConfig): void {
           }
           break;
         }
+
+        case 'policy-link': {
+          // The policy link is tagged with data-cc so it's discoverable as a
+          // consent-related element, but navigation is handled by the
+          // browser — nothing to do here. Explicitly listed so a future
+          // default case (e.g. logging unknown actions with preventDefault)
+          // doesn't accidentally break the link.
+          break;
+        }
       }
     });
 
@@ -155,20 +164,37 @@ export function initConsentManager(config: SerializableConsentConfig): void {
     get: () => readConsent(),
     set: (categories) => {
       const current = readConsent();
-      if (!current) return;
-      const merged: Record<string, boolean> = { ...current.categories, essential: true };
+      // If no consent has been recorded yet, seed it with the config defaults
+      // so callers can set categories programmatically before the banner has
+      // been interacted with.
+      const baseCategories: Record<string, boolean> = { essential: true };
+      if (current) {
+        Object.assign(baseCategories, current.categories, { essential: true });
+      } else {
+        for (const [key, cat] of Object.entries(config.categories)) {
+          baseCategories[key] = cat.default;
+        }
+      }
       for (const [key, value] of Object.entries(categories)) {
         if (key !== 'essential' && value !== undefined) {
-          merged[key] = value;
+          baseCategories[key] = value;
         }
       }
       const state: ConsentState = {
-        version: current.version,
+        version: current ? current.version : config.version,
         timestamp: Date.now(),
-        categories: merged,
+        categories: baseCategories,
       };
       writeConsent(state);
-      emit(CHANGE_EVENT, state);
+      // If this is the first consent record, the banner should disappear and
+      // a CONSENT_EVENT should fire (not CHANGE_EVENT).
+      if (!current) {
+        hideBanner();
+        consentFiredThisSession = true;
+        emit(CONSENT_EVENT, state);
+      } else {
+        emit(CHANGE_EVENT, state);
+      }
     },
     reset: () => {
       clearConsent();

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -28,10 +28,23 @@ export interface SerializableConsentConfig {
 }
 
 export interface ConsentAPI {
+  /** Returns the currently stored consent state, or `null` if none. */
   get(): ConsentState | null;
+  /**
+   * Merge a partial category map into the current state and persist it.
+   *
+   * If no consent has been recorded yet, this seeds an initial consent
+   * record from the config defaults, hides the banner, and dispatches
+   * `astro-consent:consent`. Subsequent calls merge into the existing
+   * state and dispatch `astro-consent:change` instead. The `essential`
+   * category is always forced to `true`.
+   */
   set(categories: Partial<Record<string, boolean>>): void;
+  /** Clear the stored consent and re-show the banner. */
   reset(): void;
+  /** Show the consent banner. */
   show(): void;
+  /** Open the preferences modal. */
   showPreferences(): void;
 }
 

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -43,7 +43,7 @@ function createPolicyLinkHTML(
 function createBannerHTML(config: SerializableConsentConfig): string {
   const policyLink = createPolicyLinkHTML(config.cookiePolicy, 'cc-policy-link');
   return `
-    <div class="cc-banner" id="${BANNER_ID}" role="region" aria-label="Cookie consent">
+    <div class="cc-banner" id="${BANNER_ID}" role="region" aria-label="Cookie consent" aria-hidden="true">
       <div class="cc-banner-inner">
         <p class="cc-banner-text">
           We use cookies to enhance your browsing experience, serve personalized content, and analyze our traffic.
@@ -139,11 +139,15 @@ export function injectUI(config: SerializableConsentConfig): void {
 }
 
 export function showBanner(): void {
-  document.getElementById(BANNER_ID)?.classList.add('cc-visible');
+  const el = document.getElementById(BANNER_ID);
+  el?.classList.add('cc-visible');
+  el?.setAttribute('aria-hidden', 'false');
 }
 
 export function hideBanner(): void {
-  document.getElementById(BANNER_ID)?.classList.remove('cc-visible');
+  const el = document.getElementById(BANNER_ID);
+  el?.classList.remove('cc-visible');
+  el?.setAttribute('aria-hidden', 'true');
 }
 
 /**


### PR DESCRIPTION
Closes #12, closes #13, closes #14.

## Summary

- **#12 — Banner missing `aria-hidden`**: `createBannerHTML` now renders with `aria-hidden="true"`, and `showBanner`/`hideBanner` toggle `aria-hidden` in addition to the `cc-visible` class so screen readers don't announce the banner while it's visually hidden. Matches the modal's existing behavior.
- **#13 — `api.set()` silent no-op before any consent**: Calling `window.zdenekkureckaConsent.set({ analytics: true })` before the user has interacted with the banner no longer returns early. It now seeds an initial consent record from the config defaults merged with the caller's values, hides the banner, and dispatches `astro-consent:consent`. Subsequent calls still merge into the existing state and dispatch `astro-consent:change`. `essential` remains forced to `true`.
- **#14 — `data-cc="policy-link"` unhandled in click delegation**: Added an explicit `case 'policy-link': break;` in the switch in `client.ts` with a comment explaining that navigation is handled by the browser. This documents the intent and guards against a future default case (e.g. one that calls `preventDefault()` for logging) silently breaking the policy link.

## Docs

- Expanded the `set()` description in `README.md` (the single source of truth; the package README is generated from it at build time) to describe the new seeding behavior and which event fires in each case.
- Added an Accessibility bullet noting that banner and modal both toggle `aria-hidden` in lockstep with their visibility.
- Added JSDoc to every method on `ConsentAPI` in `src/types.ts` so editor autocomplete matches the README.

## Test plan

- [ ] `pnpm --filter @zdenekkurecka/astro-consent build` succeeds (ran locally — green).
- [ ] In the playground, reload with cleared localStorage and verify the banner is rendered with `aria-hidden="true"` until it becomes visible, then flips to `false`.
- [ ] With cleared localStorage, call `window.zdenekkureckaConsent.set({ analytics: true })` from the devtools console and verify: a consent record is written, the banner hides, and `astro-consent:consent` fires once.
- [ ] Click the policy link in both the banner and the preferences modal and verify normal navigation still works.
- [ ] Screen-reader smoke test (VoiceOver / NVDA) that the hidden banner is not announced.