### PR TITLE
Release 0.1.3: configurable UI text & locale support + bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,18 @@ interface ConsentAPI {
   /** Returns the currently stored consent state, or `null` if none. */
   get(): ConsentState | null;
 
-  /** Merge a partial category map into the current state and persist it. */
+  /**
+   * Merge a partial category map into the current state and persist it.
+   *
+   * If no consent has been recorded yet (first-time visitor who has not
+   * interacted with the banner), this seeds an initial consent record from
+   * the config defaults, hides the banner, and dispatches
+   * `astro-consent:consent`. Subsequent calls merge into the existing state
+   * and dispatch `astro-consent:change` instead.
+   *
+   * The `essential` category is always forced to `true` and cannot be
+   * disabled through this method.
+   */
   set(categories: Partial<Record<string, boolean>>): void;
 
   /** Clear the stored consent and re-show the banner. */
@@ -367,7 +378,9 @@ Example:
 // Read current state
 const state = window.zdenekkureckaConsent?.get();
 
-// Programmatically update
+// Programmatically update. Safe to call before the user has interacted
+// with the banner — the missing categories fall back to your config
+// defaults and an initial consent record is written.
 window.zdenekkureckaConsent?.set({ analytics: true });
 
 // Re-open the preferences modal (e.g. from a "Cookie settings" footer link)
@@ -396,6 +409,9 @@ autocompletion on `e.detail.categories`.
 - `Tab` / `Shift+Tab` is trapped inside the modal while it's open.
 - `Escape` closes the modal and returns focus to the trigger.
 - Clicking the overlay closes the modal; the overlay itself is `aria-hidden`.
+- Banner and modal both toggle `aria-hidden` in lockstep with their
+  visibility, so screen readers don't announce them while they are
+  visually hidden.
 - All buttons have `type="button"` so they never submit ambient forms.
 
 ## Repository layout

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   - [Open the preferences modal from a footer link](#open-the-preferences-modal-from-a-footer-link)
   - [Gate third-party scripts (GA, Meta Pixel, …)](#gate-third-party-scripts-ga-meta-pixel-)
   - [Re-prompt users after changing categories](#re-prompt-users-after-changing-categories)
+  - [Customise banner & modal text (and localize it)](#customise-banner--modal-text-and-localize-it)
   - [Theme the UI](#theme-the-ui)
   - [Use with a strict Content Security Policy](#use-with-a-strict-content-security-policy)
 - [Runtime API](#runtime-api)
@@ -64,6 +65,9 @@ they force you to serialize your tracker callbacks into a JSON config.
 - **Versioned consent** — bump a number to re-prompt every user
 - **Typed** config, runtime API, and `document` event map
 - **Optional cookie policy link** surfaced in both banner and preferences modal
+- **Fully configurable UI text** with partial overrides and per-locale
+  resolution from `<html lang>` — every banner / modal string can be
+  translated or customised
 - **Accessible modal**: `role="dialog"` / `aria-modal`, focus trap, focus
   restoration, `Escape` to close, click-outside to dismiss
 - **Strict-CSP safe**: no inline `<script>`, no inline `<style>`
@@ -149,6 +153,42 @@ interface ConsentConfig {
     /** Defaults to `"Cookie Policy"`. */
     label?: string;
   };
+
+  /**
+   * Single-language text overrides for the banner and modal. Any field
+   * omitted falls back to the built-in English default. Also used as a
+   * shared fallback layer under `localeText`.
+   */
+  text?: ConsentText;
+
+  /**
+   * Per-locale text overrides. Keys are BCP 47 language tags matched
+   * against `<html lang>` at runtime (e.g. `"en"`, `"cs"`, `"en-US"`).
+   *
+   * Resolution order: exact match → primary subtag → `text` →
+   * built-in defaults.
+   */
+  localeText?: Record<string, ConsentText>;
+}
+
+interface ConsentText {
+  // Banner
+  bannerText?: string;
+  acceptAll?: string;        // shared by banner + modal
+  rejectAll?: string;        // shared by banner + modal
+  manage?: string;
+
+  // Modal
+  modalTitle?: string;
+  closeAriaLabel?: string;
+  savePreferences?: string;
+
+  // Essential category
+  essentialLabel?: string;
+  essentialDescription?: string;
+
+  /** Per-category label/description overrides (key = category key). */
+  categories?: Record<string, { label?: string; description?: string }>;
 }
 ```
 
@@ -293,6 +333,72 @@ cookieConsent({
 
 Any stored consent with a lower version is treated as missing and the banner
 re-appears for every user on their next visit.
+
+### Customise banner & modal text (and localize it)
+
+Every string in the banner and modal can be overridden. For a single-language
+site, pass a `text` object. For a multi-lingual site, pass a `localeText`
+map keyed by BCP 47 language tag — the integration reads
+`document.documentElement.lang` at runtime and picks the best match.
+
+Resolution order: **exact locale match** → **primary subtag** (e.g. `en-GB`
+falls back to `en`) → shared `text` → **built-in English defaults**. All
+fields are optional and layers compose, so you only need to supply the keys
+you actually want to change.
+
+```ts
+cookieConsent({
+  version: 1,
+  categories: {
+    analytics: { label: 'Analytics', description: '…', default: false },
+  },
+  localeText: {
+    en: {
+      bannerText: 'We use cookies to improve your experience and analyse traffic.',
+      acceptAll: 'Accept all',
+      rejectAll: 'Reject all',
+      manage: 'Manage preferences',
+      modalTitle: 'Cookie preferences',
+      closeAriaLabel: 'Close preferences',
+      savePreferences: 'Save preferences',
+      essentialLabel: 'Essential',
+      essentialDescription: 'Required for the website to function. Cannot be disabled.',
+      categories: {
+        analytics: {
+          label: 'Analytics',
+          description: 'Helps us understand how visitors use the site.',
+        },
+      },
+    },
+    cs: {
+      bannerText: 'Používáme cookies ke zlepšení vašeho zážitku a analýze návštěvnosti.',
+      acceptAll: 'Přijmout vše',
+      rejectAll: 'Odmítnout vše',
+      manage: 'Spravovat předvolby',
+      modalTitle: 'Předvolby cookies',
+      closeAriaLabel: 'Zavřít předvolby',
+      savePreferences: 'Uložit předvolby',
+      essentialLabel: 'Nezbytné',
+      essentialDescription: 'Nutné pro fungování webu. Nelze vypnout.',
+      categories: {
+        analytics: {
+          label: 'Analytické',
+          description: 'Pomáhají nám pochopit, jak návštěvníci web používají.',
+        },
+      },
+    },
+  },
+});
+```
+
+Set `<html lang="cs">` and the Czech strings render; set `<html lang="en-GB">`
+and the `en` primary-subtag fallback kicks in. If neither `text` nor a
+matching `localeText` entry is supplied, the built-in English defaults are
+used.
+
+Per-category `label` / `description` pulled from `localeText` override the
+ones declared in `categories`, so you can keep a single category-key
+definition and translate its user-visible labels per language.
 
 ### Theme the UI
 

--- a/packages/astro-consent/package.json
+++ b/packages/astro-consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zdenekkurecka/astro-consent",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Astro integration for GDPR/ePrivacy-friendly cookie consent: banner, preferences modal, runtime API, category-based consent state, strict-CSP safe, works with or without View Transitions.",
   "keywords": [
     "astro",

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -11,6 +11,7 @@ import {
 } from './consent.js';
 import {
   injectUI,
+  resolveText,
   showBanner,
   hideBanner,
   showModal,
@@ -36,8 +37,13 @@ function emit(type: typeof CONSENT_EVENT | typeof CHANGE_EVENT, state: ConsentSt
 }
 
 export function initConsentManager(config: SerializableConsentConfig): void {
+  // Resolve UI text once per init: reads <html lang>, merges built-in
+  // defaults → config.text → localeText[lang]. Passed to every injectUI call
+  // below so reset/show/showPreferences use the same resolved strings.
+  const text = resolveText(config);
+
   // Inject banner + modal DOM (idempotent).
-  injectUI(config);
+  injectUI(config, text);
 
   // Check consent state.
   if (needsConsent(config.version)) {
@@ -198,15 +204,15 @@ export function initConsentManager(config: SerializableConsentConfig): void {
     },
     reset: () => {
       clearConsent();
-      injectUI(config);
+      injectUI(config, text);
       showBanner();
     },
     show: () => {
-      injectUI(config);
+      injectUI(config, text);
       showBanner();
     },
     showPreferences: () => {
-      injectUI(config);
+      injectUI(config, text);
       hideBanner();
       const current = readConsent();
       if (current) {

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -121,6 +121,15 @@ export function initConsentManager(config: SerializableConsentConfig): void {
           }
           break;
         }
+
+        case 'policy-link': {
+          // The policy link is tagged with data-cc so it's discoverable as a
+          // consent-related element, but navigation is handled by the
+          // browser — nothing to do here. Explicitly listed so a future
+          // default case (e.g. logging unknown actions with preventDefault)
+          // doesn't accidentally break the link.
+          break;
+        }
       }
     });
 
@@ -155,20 +164,37 @@ export function initConsentManager(config: SerializableConsentConfig): void {
     get: () => readConsent(),
     set: (categories) => {
       const current = readConsent();
-      if (!current) return;
-      const merged: Record<string, boolean> = { ...current.categories, essential: true };
+      // If no consent has been recorded yet, seed it with the config defaults
+      // so callers can set categories programmatically before the banner has
+      // been interacted with.
+      const baseCategories: Record<string, boolean> = { essential: true };
+      if (current) {
+        Object.assign(baseCategories, current.categories, { essential: true });
+      } else {
+        for (const [key, cat] of Object.entries(config.categories)) {
+          baseCategories[key] = cat.default;
+        }
+      }
       for (const [key, value] of Object.entries(categories)) {
         if (key !== 'essential' && value !== undefined) {
-          merged[key] = value;
+          baseCategories[key] = value;
         }
       }
       const state: ConsentState = {
-        version: current.version,
+        version: current ? current.version : config.version,
         timestamp: Date.now(),
-        categories: merged,
+        categories: baseCategories,
       };
       writeConsent(state);
-      emit(CHANGE_EVENT, state);
+      // If this is the first consent record, the banner should disappear and
+      // a CONSENT_EVENT should fire (not CHANGE_EVENT).
+      if (!current) {
+        hideBanner();
+        consentFiredThisSession = true;
+        emit(CONSENT_EVENT, state);
+      } else {
+        emit(CHANGE_EVENT, state);
+      }
     },
     reset: () => {
       clearConsent();

--- a/packages/astro-consent/src/index.ts
+++ b/packages/astro-consent/src/index.ts
@@ -1,2 +1,9 @@
 export { default } from './integration.js';
-export type { ConsentConfig, ConsentState, ConsentCategory, ConsentAPI } from './types.js';
+export type {
+  ConsentConfig,
+  ConsentState,
+  ConsentCategory,
+  ConsentCategoryText,
+  ConsentText,
+  ConsentAPI,
+} from './types.js';

--- a/packages/astro-consent/src/integration.ts
+++ b/packages/astro-consent/src/integration.ts
@@ -7,6 +7,8 @@ export default function cookieConsent(userConfig: ConsentConfig): AstroIntegrati
     version: userConfig.version,
     categories: userConfig.categories,
     cookiePolicy: userConfig.cookiePolicy,
+    text: userConfig.text,
+    localeText: userConfig.localeText,
   };
 
   return {

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -9,10 +9,55 @@ export interface CookiePolicyLink {
   label?: string;
 }
 
+/** Per-category label/description override used in `ConsentText.categories`. */
+export interface ConsentCategoryText {
+  label?: string;
+  description?: string;
+}
+
+/**
+ * UI text overrides for the consent banner and preferences modal.
+ *
+ * All fields are optional. Unspecified fields fall back to the built-in
+ * English defaults, so you only need to provide the strings you want to
+ * change.
+ */
+export interface ConsentText {
+  // Banner
+  bannerText?: string;
+  acceptAll?: string;
+  rejectAll?: string;
+  manage?: string;
+
+  // Modal
+  modalTitle?: string;
+  closeAriaLabel?: string;
+  savePreferences?: string;
+
+  // Essential category
+  essentialLabel?: string;
+  essentialDescription?: string;
+
+  /** Per-category label/description overrides, keyed by category key. */
+  categories?: Record<string, ConsentCategoryText>;
+}
+
 export interface ConsentConfig {
   version: number;
   categories: Record<string, ConsentCategory>;
   cookiePolicy?: CookiePolicyLink;
+
+  /** Single-language text overrides, or shared fallback for `localeText`. */
+  text?: ConsentText;
+
+  /**
+   * Per-locale text overrides. Keys are BCP 47 language tags that match the
+   * `<html lang>` attribute (e.g. `"en"`, `"cs"`, `"en-US"`).
+   *
+   * Resolution order at runtime: exact match → primary subtag → `text` →
+   * built-in defaults.
+   */
+  localeText?: Record<string, ConsentText>;
 }
 
 export interface ConsentState {
@@ -25,6 +70,8 @@ export interface SerializableConsentConfig {
   version: number;
   categories: Record<string, ConsentCategory>;
   cookiePolicy?: CookiePolicyLink;
+  text?: ConsentText;
+  localeText?: Record<string, ConsentText>;
 }
 
 export interface ConsentAPI {

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -28,10 +28,23 @@ export interface SerializableConsentConfig {
 }
 
 export interface ConsentAPI {
+  /** Returns the currently stored consent state, or `null` if none. */
   get(): ConsentState | null;
+  /**
+   * Merge a partial category map into the current state and persist it.
+   *
+   * If no consent has been recorded yet, this seeds an initial consent
+   * record from the config defaults, hides the banner, and dispatches
+   * `astro-consent:consent`. Subsequent calls merge into the existing
+   * state and dispatch `astro-consent:change` instead. The `essential`
+   * category is always forced to `true`.
+   */
   set(categories: Partial<Record<string, boolean>>): void;
+  /** Clear the stored consent and re-show the banner. */
   reset(): void;
+  /** Show the consent banner. */
   show(): void;
+  /** Open the preferences modal. */
   showPreferences(): void;
 }
 

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -43,7 +43,7 @@ function createPolicyLinkHTML(
 function createBannerHTML(config: SerializableConsentConfig): string {
   const policyLink = createPolicyLinkHTML(config.cookiePolicy, 'cc-policy-link');
   return `
-    <div class="cc-banner" id="${BANNER_ID}" role="region" aria-label="Cookie consent">
+    <div class="cc-banner" id="${BANNER_ID}" role="region" aria-label="Cookie consent" aria-hidden="true">
       <div class="cc-banner-inner">
         <p class="cc-banner-text">
           We use cookies to enhance your browsing experience, serve personalized content, and analyze our traffic.
@@ -139,11 +139,15 @@ export function injectUI(config: SerializableConsentConfig): void {
 }
 
 export function showBanner(): void {
-  document.getElementById(BANNER_ID)?.classList.add('cc-visible');
+  const el = document.getElementById(BANNER_ID);
+  el?.classList.add('cc-visible');
+  el?.setAttribute('aria-hidden', 'false');
 }
 
 export function hideBanner(): void {
-  document.getElementById(BANNER_ID)?.classList.remove('cc-visible');
+  const el = document.getElementById(BANNER_ID);
+  el?.classList.remove('cc-visible');
+  el?.setAttribute('aria-hidden', 'true');
 }
 
 /**

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -1,4 +1,118 @@
-import type { SerializableConsentConfig } from './types.js';
+import type {
+  ConsentCategory,
+  ConsentCategoryText,
+  ConsentText,
+  SerializableConsentConfig,
+} from './types.js';
+
+/**
+ * Fully-resolved UI text used internally after merging built-in defaults,
+ * single-language `text` overrides, and the active locale entry.
+ */
+export type ResolvedConsentText = Required<Omit<ConsentText, 'categories'>> & {
+  categories: Record<string, ConsentCategoryText>;
+};
+
+/** Built-in English defaults. Every non-category field is a complete string. */
+const BUILT_IN_DEFAULTS: ResolvedConsentText = {
+  bannerText:
+    'We use cookies to enhance your browsing experience, serve personalized content, and analyze our traffic. Please choose your cookie preferences.',
+  acceptAll: 'Accept all',
+  rejectAll: 'Reject all',
+  manage: 'Manage preferences',
+  modalTitle: 'Cookie preferences',
+  closeAriaLabel: 'Close preferences',
+  savePreferences: 'Save preferences',
+  essentialLabel: 'Essential',
+  essentialDescription: 'Required for the website to function. Cannot be disabled.',
+  categories: {},
+};
+
+/**
+ * Merge a partial `ConsentText` layer onto an already-resolved base, returning
+ * a new resolved text. Only keys explicitly present in `layer` override the
+ * base; `undefined` values are ignored so partial layers compose correctly.
+ * The nested `categories` map is merged per-key, with each per-category
+ * override itself being a partial merge.
+ */
+function mergeText(base: ResolvedConsentText, layer: ConsentText | undefined): ResolvedConsentText {
+  if (!layer) return base;
+  const next: ResolvedConsentText = { ...base, categories: { ...base.categories } };
+
+  if (layer.bannerText !== undefined) next.bannerText = layer.bannerText;
+  if (layer.acceptAll !== undefined) next.acceptAll = layer.acceptAll;
+  if (layer.rejectAll !== undefined) next.rejectAll = layer.rejectAll;
+  if (layer.manage !== undefined) next.manage = layer.manage;
+  if (layer.modalTitle !== undefined) next.modalTitle = layer.modalTitle;
+  if (layer.closeAriaLabel !== undefined) next.closeAriaLabel = layer.closeAriaLabel;
+  if (layer.savePreferences !== undefined) next.savePreferences = layer.savePreferences;
+  if (layer.essentialLabel !== undefined) next.essentialLabel = layer.essentialLabel;
+  if (layer.essentialDescription !== undefined) {
+    next.essentialDescription = layer.essentialDescription;
+  }
+
+  if (layer.categories) {
+    for (const [key, override] of Object.entries(layer.categories)) {
+      if (!override) continue;
+      const existing = next.categories[key];
+      next.categories[key] = {
+        label: override.label ?? existing?.label,
+        description: override.description ?? existing?.description,
+      };
+    }
+  }
+
+  return next;
+}
+
+/**
+ * Resolve the UI text layers for the current document.
+ *
+ * Reads `document.documentElement.lang`, picks the best match from
+ * `config.localeText` (exact tag → primary subtag), and deep-merges the
+ * layers: built-in defaults → `config.text` → resolved locale entry. Partial
+ * overrides compose correctly — callers only need to supply the keys they
+ * want to change.
+ */
+export function resolveText(config: SerializableConsentConfig): ResolvedConsentText {
+  let resolved = mergeText(BUILT_IN_DEFAULTS, config.text);
+
+  const localeText = config.localeText;
+  if (localeText) {
+    // `document.documentElement` exists whenever this runs (client-side only).
+    const lang = (document.documentElement.lang || '').trim();
+    if (lang) {
+      const exact = localeText[lang];
+      if (exact) {
+        resolved = mergeText(resolved, exact);
+      } else {
+        const primary = lang.split('-')[0];
+        if (primary && primary !== lang) {
+          const sub = localeText[primary];
+          if (sub) resolved = mergeText(resolved, sub);
+        }
+      }
+    }
+  }
+
+  return resolved;
+}
+
+/**
+ * Pick the label/description for a category, preferring any resolved text
+ * override and falling back to the config-supplied category definition.
+ */
+function resolveCategoryText(
+  key: string,
+  fallback: Pick<ConsentCategory, 'label' | 'description'>,
+  text: ResolvedConsentText,
+): { label: string; description: string } {
+  const override = text.categories[key];
+  return {
+    label: override?.label ?? fallback.label,
+    description: override?.description ?? fallback.description,
+  };
+}
 
 const CONTAINER_ID = 'cc-container';
 const MODAL_ID = 'cc-modal';
@@ -40,20 +154,19 @@ function createPolicyLinkHTML(
   return `<a class="${className}" href="${escapeHtml(safeUrl)}" data-cc="policy-link">${escapeHtml(label)}</a>`;
 }
 
-function createBannerHTML(config: SerializableConsentConfig): string {
+function createBannerHTML(config: SerializableConsentConfig, text: ResolvedConsentText): string {
   const policyLink = createPolicyLinkHTML(config.cookiePolicy, 'cc-policy-link');
   return `
     <div class="cc-banner" id="${BANNER_ID}" role="region" aria-label="Cookie consent" aria-hidden="true">
       <div class="cc-banner-inner">
         <p class="cc-banner-text">
-          We use cookies to enhance your browsing experience, serve personalized content, and analyze our traffic.
-          Please choose your cookie preferences.
+          ${escapeHtml(text.bannerText)}
           ${policyLink}
         </p>
         <div class="cc-banner-actions">
-          <button type="button" class="cc-btn cc-btn-primary" data-cc="accept-all">Accept all</button>
-          <button type="button" class="cc-btn cc-btn-secondary" data-cc="reject-all">Reject all</button>
-          <button type="button" class="cc-btn cc-btn-link" data-cc="manage">Manage preferences</button>
+          <button type="button" class="cc-btn cc-btn-primary" data-cc="accept-all">${escapeHtml(text.acceptAll)}</button>
+          <button type="button" class="cc-btn cc-btn-secondary" data-cc="reject-all">${escapeHtml(text.rejectAll)}</button>
+          <button type="button" class="cc-btn cc-btn-link" data-cc="manage">${escapeHtml(text.manage)}</button>
         </div>
       </div>
     </div>`;
@@ -84,17 +197,20 @@ function createCategoryToggle(
     </div>`;
 }
 
-function createModalHTML(config: SerializableConsentConfig): string {
+function createModalHTML(config: SerializableConsentConfig, text: ResolvedConsentText): string {
   const essentialToggle = createCategoryToggle(
     'essential',
-    'Essential',
-    'Required for the website to function. Cannot be disabled.',
+    text.essentialLabel,
+    text.essentialDescription,
     true,
     true,
   );
 
   const categoryToggles = Object.entries(config.categories)
-    .map(([key, cat]) => createCategoryToggle(key, cat.label, cat.description, false, cat.default))
+    .map(([key, cat]) => {
+      const resolved = resolveCategoryText(key, cat, text);
+      return createCategoryToggle(key, resolved.label, resolved.description, false, cat.default);
+    })
     .join('');
 
   const policyLink = createPolicyLinkHTML(config.cookiePolicy, 'cc-policy-link cc-modal-policy-link');
@@ -112,8 +228,8 @@ function createModalHTML(config: SerializableConsentConfig): string {
     >
       <div class="cc-modal-inner">
         <div class="cc-modal-header">
-          <h2 class="cc-modal-title" id="${MODAL_TITLE_ID}">Cookie preferences</h2>
-          <button type="button" class="cc-modal-close" data-cc="close-modal" aria-label="Close preferences">&times;</button>
+          <h2 class="cc-modal-title" id="${MODAL_TITLE_ID}">${escapeHtml(text.modalTitle)}</h2>
+          <button type="button" class="cc-modal-close" data-cc="close-modal" aria-label="${escapeHtml(text.closeAriaLabel)}">&times;</button>
         </div>
         <div class="cc-modal-body">
           ${essentialToggle}
@@ -121,20 +237,20 @@ function createModalHTML(config: SerializableConsentConfig): string {
           ${policyLink}
         </div>
         <div class="cc-modal-footer">
-          <button type="button" class="cc-btn cc-btn-primary" data-cc="modal-accept-all">Accept all</button>
-          <button type="button" class="cc-btn cc-btn-secondary" data-cc="modal-reject-all">Reject all</button>
-          <button type="button" class="cc-btn cc-btn-primary" data-cc="save-preferences">Save preferences</button>
+          <button type="button" class="cc-btn cc-btn-primary" data-cc="modal-accept-all">${escapeHtml(text.acceptAll)}</button>
+          <button type="button" class="cc-btn cc-btn-secondary" data-cc="modal-reject-all">${escapeHtml(text.rejectAll)}</button>
+          <button type="button" class="cc-btn cc-btn-primary" data-cc="save-preferences">${escapeHtml(text.savePreferences)}</button>
         </div>
       </div>
     </div>`;
 }
 
-export function injectUI(config: SerializableConsentConfig): void {
+export function injectUI(config: SerializableConsentConfig, text: ResolvedConsentText): void {
   if (document.getElementById(CONTAINER_ID)) return;
 
   const container = document.createElement('div');
   container.id = CONTAINER_ID;
-  container.innerHTML = createBannerHTML(config) + createModalHTML(config);
+  container.innerHTML = createBannerHTML(config, text) + createModalHTML(config, text);
   document.body.appendChild(container);
 }
 


### PR DESCRIPTION
Promotes `dev` to `main` for the 0.1.3 release.

## Summary

### Features

- **Configurable UI text and locale support (#15)** — every string in the banner and preferences modal can now be overridden or translated. Adds a new `ConsentText` type and optional `text` / `localeText` fields on `ConsentConfig`. At init the client reads `<html lang>` and resolves the best locale entry (exact tag → primary subtag → shared `text` → built-in English defaults), then threads the resolved strings through `injectUI`. Partial overrides compose, so callers only supply the keys they want to change. Per-category `label` / `description` from `localeText` override the ones declared in `categories`.

### Bug fixes

- **#12** — Toggle `aria-hidden` on the banner in `show`/`hideBanner` and render it with `aria-hidden="true"` initially, so screen readers don't announce the banner while it is visually hidden.
- **#13** — `api.set()` no longer silently no-ops when called before any consent has been recorded. It seeds an initial consent record from the config defaults, hides the banner, and emits `CONSENT_EVENT` on the first write (`CHANGE_EVENT` on subsequent updates).
- **#14** — Add an explicit `policy-link` case in the click delegation switch so the `data-cc` policy anchor is acknowledged as a consent-related element without a future default case accidentally breaking navigation.

### Docs

- README: new "Customise banner & modal text (and localize it)" how-to, new Features bullet, TOC entry, and extended `ConsentConfig` / `ConsentText` interface documentation.
- README: updates reflecting the a11y / API / delegation bug fixes from #12, #13, #14.

### Release

- `packages/astro-consent` version bumped to `0.1.3`.

## Test plan

- [ ] `pnpm --filter @zdenekkurecka/astro-consent build` passes cleanly
- [ ] Smoke-test banner + modal with default config (English, built-in strings)
- [ ] Smoke-test `localeText` with `<html lang="cs">` and `<html lang="en-GB">` (primary subtag fallback)
- [ ] Verify `api.set()` from a clean state seeds defaults, hides banner, fires `CONSENT_EVENT`
- [ ] Verify cookie policy link still navigates correctly

https://claude.ai/code/session_01NgX9qagDv5Wf9uT6aDHF2a