### PR TITLE
feat(consent): configurable storageKey (#29)

### DIFF
--- a/.changeset/configurable-storage-key.md
+++ b/.changeset/configurable-storage-key.md
@@ -1,0 +1,5 @@
+---
+'@zdenekkurecka/astro-consent': minor
+---
+
+Add `storageKey` config option to override the localStorage key used to persist consent. Prevents collisions when multiple Astro apps share a single origin (e.g. `example.com/docs` and `example.com/app`). Defaults to `"astro-consent"`.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ interface ConsentConfig {
   };
 
   /**
+   * localStorage key used to persist the consent record. Override this when
+   * multiple Astro apps share a single origin (e.g. `example.com/docs` and
+   * `example.com/app`) so they don't clobber each other's state.
+   *
+   * @default "astro-consent"
+   */
+  storageKey?: string;
+
+  /**
    * Single-language text overrides for the banner and modal. Any field
    * omitted falls back to the built-in English default. Also used as a
    * shared fallback layer under `localeText`.

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -8,6 +8,7 @@ import {
   acceptAll,
   rejectAll,
   savePreferences,
+  setStorageKey,
 } from './consent.js';
 import {
   injectUI,
@@ -37,6 +38,10 @@ function emit(type: typeof CONSENT_EVENT | typeof CHANGE_EVENT, state: ConsentSt
 }
 
 export function initConsentManager(config: SerializableConsentConfig): void {
+  // Apply the configured localStorage key before any read/write so multiple
+  // Astro apps on the same origin don't clobber each other's consent state.
+  setStorageKey(config.storageKey);
+
   // Resolve UI text once per init: reads <html lang>, merges built-in
   // defaults → config.text → localeText[lang]. Passed to every injectUI call
   // below so reset/show/showPreferences use the same resolved strings.

--- a/packages/astro-consent/src/consent.ts
+++ b/packages/astro-consent/src/consent.ts
@@ -1,6 +1,11 @@
 import type { ConsentState, SerializableConsentConfig } from './types.js';
 
-const STORAGE_KEY = 'astro-consent';
+const DEFAULT_STORAGE_KEY = 'astro-consent';
+let STORAGE_KEY: string = DEFAULT_STORAGE_KEY;
+
+export function setStorageKey(key: string | undefined): void {
+  STORAGE_KEY = key || DEFAULT_STORAGE_KEY;
+}
 
 export function readConsent(): ConsentState | null {
   try {

--- a/packages/astro-consent/src/integration.ts
+++ b/packages/astro-consent/src/integration.ts
@@ -7,6 +7,7 @@ export default function cookieConsent(userConfig: ConsentConfig): AstroIntegrati
     version: userConfig.version,
     categories: userConfig.categories,
     cookiePolicy: userConfig.cookiePolicy,
+    storageKey: userConfig.storageKey,
     text: userConfig.text,
     localeText: userConfig.localeText,
   };

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -47,6 +47,15 @@ export interface ConsentConfig {
   categories: Record<string, ConsentCategory>;
   cookiePolicy?: CookiePolicyLink;
 
+  /**
+   * localStorage key used to persist the consent record. Override this when
+   * multiple Astro apps share a single origin (e.g. `example.com/docs` and
+   * `example.com/app`) to prevent them from clobbering each other's state.
+   *
+   * @default "astro-consent"
+   */
+  storageKey?: string;
+
   /** Single-language text overrides, or shared fallback for `localeText`. */
   text?: ConsentText;
 
@@ -70,6 +79,7 @@ export interface SerializableConsentConfig {
   version: number;
   categories: Record<string, ConsentCategory>;
   cookiePolicy?: CookiePolicyLink;
+  storageKey?: string;
   text?: ConsentText;
   localeText?: Record<string, ConsentText>;
 }


### PR DESCRIPTION
## Summary
- Adds optional `storageKey` to `ConsentConfig` so apps on a shared origin (e.g. `example.com/docs` + `example.com/app`) don't clobber each other's consent state.
- `consent.ts` now holds the key in a module-level `let` initialized via `setStorageKey()`, called from `initConsentManager()` before any read/write.
- Defaults to `"astro-consent"` — zero breaking changes for existing installs.

Closes #29.

## Test plan
- [x] `pnpm -C packages/astro-consent build` passes (tsc typecheck)
- [x] Verify two playground apps on the same origin with different `storageKey` values persist independently
- [x] Verify existing installs with no `storageKey` still read/write `astro-consent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)