### PR TITLE
feat(consent): maxAgeDays TTL for stored consent

### DIFF
--- a/.changeset/consent-expiry-ttl.md
+++ b/.changeset/consent-expiry-ttl.md
@@ -1,0 +1,5 @@
+---
+'@zdenekkurecka/astro-consent': minor
+---
+
+Add `maxAgeDays` config option to expire stored consent after N days and re-prompt the user. Useful for aligning with GDPR/DPA guidance that recommends re-asking for consent every 6–12 months. Defaults to `undefined` (no expiry).

--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ interface ConsentConfig {
   storageKey?: string;
 
   /**
+   * Maximum age of a stored consent record, in days. When set, a consent
+   * record older than this is treated as missing and the banner is
+   * re-shown — useful for complying with GDPR/DPA guidance that
+   * recommends re-prompting every 6–12 months.
+   *
+   * @default undefined (no expiry)
+   */
+  maxAgeDays?: number;
+
+  /**
    * Single-language text overrides for the banner and modal. Any field
    * omitted falls back to the built-in English default. Also used as a
    * shared fallback layer under `localeText`.

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -51,7 +51,7 @@ export function initConsentManager(config: SerializableConsentConfig): void {
   injectUI(config, text);
 
   // Check consent state.
-  if (needsConsent(config.version)) {
+  if (needsConsent(config.version, config.maxAgeDays)) {
     showBanner();
   } else if (!consentFiredThisSession) {
     // Fire the consent event once per session (not on every SPA navigation).
@@ -115,7 +115,7 @@ export function initConsentManager(config: SerializableConsentConfig): void {
 
         case 'save-preferences': {
           const selections = getModalSelections();
-          const isUpdate = !needsConsent(config.version);
+          const isUpdate = !needsConsent(config.version, config.maxAgeDays);
           const state = savePreferences(config, selections);
           writeConsent(state);
           hideModal();
@@ -127,7 +127,7 @@ export function initConsentManager(config: SerializableConsentConfig): void {
         case 'close-modal': {
           hideModal();
           // Re-show banner if consent hasn't been given yet.
-          if (needsConsent(config.version)) {
+          if (needsConsent(config.version, config.maxAgeDays)) {
             showBanner();
           }
           break;
@@ -148,7 +148,7 @@ export function initConsentManager(config: SerializableConsentConfig): void {
     document.addEventListener('click', (e) => {
       if ((e.target as HTMLElement).id === 'cc-overlay') {
         hideModal();
-        if (needsConsent(config.version)) {
+        if (needsConsent(config.version, config.maxAgeDays)) {
           showBanner();
         }
       }
@@ -160,7 +160,7 @@ export function initConsentManager(config: SerializableConsentConfig): void {
 
       if (e.key === 'Escape') {
         hideModal();
-        if (needsConsent(config.version)) {
+        if (needsConsent(config.version, config.maxAgeDays)) {
           showBanner();
         }
         return;

--- a/packages/astro-consent/src/consent.ts
+++ b/packages/astro-consent/src/consent.ts
@@ -33,9 +33,14 @@ export function clearConsent(): void {
   }
 }
 
-export function needsConsent(configVersion: number): boolean {
+export function needsConsent(configVersion: number, maxAgeDays?: number): boolean {
   const state = readConsent();
-  return !state || state.version < configVersion;
+  if (!state || state.version < configVersion) return true;
+  if (maxAgeDays !== undefined) {
+    const ageMs = Date.now() - state.timestamp;
+    if (ageMs > maxAgeDays * 86_400_000) return true;
+  }
+  return false;
 }
 
 export function acceptAll(config: SerializableConsentConfig): ConsentState {

--- a/packages/astro-consent/src/integration.ts
+++ b/packages/astro-consent/src/integration.ts
@@ -8,6 +8,7 @@ export default function cookieConsent(userConfig: ConsentConfig): AstroIntegrati
     categories: userConfig.categories,
     cookiePolicy: userConfig.cookiePolicy,
     storageKey: userConfig.storageKey,
+    maxAgeDays: userConfig.maxAgeDays,
     text: userConfig.text,
     localeText: userConfig.localeText,
   };

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -56,6 +56,16 @@ export interface ConsentConfig {
    */
   storageKey?: string;
 
+  /**
+   * Maximum age of a stored consent record, in days. When set, consent older
+   * than this is treated as missing and the banner is re-shown. Useful for
+   * aligning with GDPR/DPA guidance that recommends re-prompting every 6–12
+   * months.
+   *
+   * @default undefined (no expiry)
+   */
+  maxAgeDays?: number;
+
   /** Single-language text overrides, or shared fallback for `localeText`. */
   text?: ConsentText;
 
@@ -80,6 +90,7 @@ export interface SerializableConsentConfig {
   categories: Record<string, ConsentCategory>;
   cookiePolicy?: CookiePolicyLink;
   storageKey?: string;
+  maxAgeDays?: number;
   text?: ConsentText;
   localeText?: Record<string, ConsentText>;
 }


### PR DESCRIPTION
Closes #30

## Summary
- Adds optional `maxAgeDays` config option to `ConsentConfig`
- `needsConsent(version, maxAgeDays?)` now treats consent older than the TTL as missing and re-shows the banner
- Wires the value through `integration.ts` into `SerializableConsentConfig` and all `client.ts` call sites
- Aligns with GDPR/DPA guidance recommending re-prompting every 6–12 months; defaults to `undefined` (no expiry)

## Test plan
- [x] Set `maxAgeDays: 1` in playground config, backdate `localStorage['astro-consent'].timestamp` by >1 day, reload — banner re-appears
- [x] Omit `maxAgeDays` — existing consent remains valid indefinitely (no regression)
- [x] Fresh consent within TTL — banner stays hidden, `astro-consent:consent` fires once per session

🤖 Generated with [Claude Code](https://claude.com/claude-code)