### PR TITLE
feat(consent): alias global API to window.astroConsent (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ A classic "Cookie settings" link in your footer:
 Or programmatically, from anywhere in your app:
 
 ```ts
-window.zdenekkureckaConsent?.showPreferences();
+window.astroConsent?.showPreferences();
 ```
 
 ### Gate third-party scripts (GA, Meta Pixel, …)
@@ -459,7 +459,8 @@ through Astro's CSS extractor and becomes a hashed external stylesheet).
 
 ## Runtime API
 
-A global `window.zdenekkureckaConsent` is exposed:
+A global `window.astroConsent` is exposed (also aliased as
+`window.zdenekkureckaConsent`, deprecated):
 
 ```ts
 interface ConsentAPI {
@@ -501,18 +502,18 @@ Example:
 
 ```ts
 // Read current state
-const state = window.zdenekkureckaConsent?.get();
+const state = window.astroConsent?.get();
 
 // Programmatically update. Safe to call before the user has interacted
 // with the banner — the missing categories fall back to your config
 // defaults and an initial consent record is written.
-window.zdenekkureckaConsent?.set({ analytics: true });
+window.astroConsent?.set({ analytics: true });
 
 // Re-open the preferences modal (e.g. from a "Cookie settings" footer link)
-window.zdenekkureckaConsent?.showPreferences();
+window.astroConsent?.showPreferences();
 
 // Clear consent and re-prompt
-window.zdenekkureckaConsent?.reset();
+window.astroConsent?.reset();
 ```
 
 ## Events

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -233,5 +233,6 @@ export function initConsentManager(config: SerializableConsentConfig): void {
     },
   };
 
+  window.astroConsent = api;
   window.zdenekkureckaConsent = api;
 }

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -143,6 +143,8 @@ declare global {
   }
 
   interface Window {
+    astroConsent?: ConsentAPI;
+    /** @deprecated Use `astroConsent` instead. */
     zdenekkureckaConsent?: ConsentAPI;
   }
 }

--- a/playground/src/pages/about.astro
+++ b/playground/src/pages/about.astro
@@ -16,7 +16,7 @@ import Layout from '../layouts/Layout.astro';
   <script>
     document.addEventListener('astro:page-load', () => {
       const el = document.getElementById('state');
-      const consent = (window as any).zdenekkureckaConsent;
+      const consent = (window as any).astroConsent;
       if (el && consent) {
         const state = consent.get();
         el.textContent = state ? JSON.stringify(state, null, 2) : 'No consent data yet.';

--- a/playground/src/pages/index.astro
+++ b/playground/src/pages/index.astro
@@ -33,7 +33,7 @@ import Layout from '../layouts/Layout.astro';
   <script>
     function refreshState() {
       const el = document.getElementById('state');
-      const consent = window.zdenekkureckaConsent;
+      const consent = window.astroConsent;
       if (el && consent) {
         const state = consent.get();
         el.textContent = state ? JSON.stringify(state, null, 2) : 'No consent data yet.';
@@ -56,15 +56,15 @@ import Layout from '../layouts/Layout.astro';
       refreshState();
 
       document.getElementById('btn-show')?.addEventListener('click', () => {
-        window.zdenekkureckaConsent?.show();
+        window.astroConsent?.show();
       });
 
       document.getElementById('btn-prefs')?.addEventListener('click', () => {
-        window.zdenekkureckaConsent?.showPreferences();
+        window.astroConsent?.showPreferences();
       });
 
       document.getElementById('btn-reset')?.addEventListener('click', () => {
-        window.zdenekkureckaConsent?.reset();
+        window.astroConsent?.reset();
         refreshState();
       });
 


### PR DESCRIPTION
## Summary
- Expose runtime API as `window.astroConsent` (primary name)
- Keep `window.zdenekkureckaConsent` as a deprecated alias for backward compat
- Update README examples and playground pages to use the new name

Closes #31

## Test plan
- [x] `pnpm --filter astro-consent build` passes
- [x] Playground: verify `window.astroConsent.get()` works in devtools
- [x] Playground: verify deprecated alias still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)