### PR TITLE
feat(consent): debug mode for development (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   - [Customise banner & modal text (and localize it)](#customise-banner--modal-text-and-localize-it)
   - [Theme the UI](#theme-the-ui)
   - [Use with a strict Content Security Policy](#use-with-a-strict-content-security-policy)
+  - [Debug mode](#debug-mode)
 - [Runtime API](#runtime-api)
 - [Events](#events)
 - [Accessibility](#accessibility)
@@ -172,6 +173,16 @@ interface ConsentConfig {
    * @default undefined (no expiry)
    */
   maxAgeDays?: number;
+
+  /**
+   * Enables verbose `console.debug` logging of runtime events (init, banner
+   * show, accept/reject/save, event dispatch, storage writes) and exposes
+   * `window.astroConsent.debug()` for an on-demand state dump. Gate it
+   * behind `import.meta.env.DEV` so it never ships to production.
+   *
+   * @default false
+   */
+  debug?: boolean;
 
   /**
    * Single-language text overrides for the banner and modal. Any field
@@ -457,6 +468,48 @@ integration only uses `injectScript('page', ...)` (emitted as a hashed
 external module script) and `injectScript('page-ssr', ...)` (which flows
 through Astro's CSS extractor and becomes a hashed external stylesheet).
 
+### Debug mode
+
+During local integration work it can be hard to tell what the runtime is
+doing — which events fired, which locale was resolved, whether the stored
+version still matches. Set `debug: true` to opt in to verbose logging. Gate
+it on `import.meta.env.DEV` so it never ships to production:
+
+```js
+// astro.config.mjs
+cookieConsent({
+  version: 1,
+  debug: import.meta.env.DEV,
+  categories: { /* ... */ },
+});
+```
+
+With debug on, the runtime emits `console.debug('[astro-consent]', …)` at
+every lifecycle point: init (with version, resolved locale, stored consent),
+banner show, accept/reject/save clicks, event dispatches, and localStorage
+writes. Because it uses `console.debug`, you need to include **Verbose** in
+your DevTools log level to see the messages.
+
+You also get an on-demand snapshot helper:
+
+```js
+window.astroConsent.debug();
+// groups and returns:
+// {
+//   config,          // the full serialized integration config
+//   resolvedLocale,  // matched <html lang> key, or null
+//   resolvedText,    // fully merged UI text used by the banner/modal
+//   storageKey,      // active localStorage key
+//   state,           // current ConsentState, or null
+//   versionMatch,    // stored version === config version
+//   needsConsent,    // true if banner would be shown right now
+// }
+```
+
+`astroConsent.debug` is only attached when `debug: true`, so production
+bundles stay clean. Typed as optional in `ConsentAPI`, so TypeScript will
+remind you to null-check it.
+
 ## Runtime API
 
 A global `window.astroConsent` is exposed (also aliased as
@@ -489,6 +542,14 @@ interface ConsentAPI {
 
   /** Open the preferences modal. */
   showPreferences(): void;
+
+  /**
+   * Dumps the current config, resolved locale/text, storage key, stored
+   * state, and version/needs-consent flags to a `console.group`, and
+   * returns the same snapshot. Only attached when the integration is
+   * configured with `debug: true`.
+   */
+  debug?(): ConsentDebugSnapshot;
 }
 
 interface ConsentState {

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -1,4 +1,9 @@
-import type { ConsentState, SerializableConsentConfig, ConsentAPI } from './types.js';
+import type {
+  ConsentState,
+  SerializableConsentConfig,
+  ConsentAPI,
+  ConsentDebugSnapshot,
+} from './types.js';
 import { CONSENT_EVENT, CHANGE_EVENT } from './types.js';
 import {
   readConsent,
@@ -9,10 +14,12 @@ import {
   rejectAll,
   savePreferences,
   setStorageKey,
+  getStorageKey,
 } from './consent.js';
 import {
   injectUI,
   resolveText,
+  resolveLocale,
   showBanner,
   hideBanner,
   showModal,
@@ -22,6 +29,15 @@ import {
   updateModalToggles,
   handleModalTabTrap,
 } from './ui.js';
+
+const LOG_PREFIX = '[astro-consent]';
+
+function log(enabled: boolean | undefined, ...args: unknown[]): void {
+  if (!enabled) return;
+  // console.debug is filterable separately from .log in DevTools and is
+  // stripped by default in Chrome's standard log level.
+  console.debug(LOG_PREFIX, ...args);
+}
 
 let listenerAttached = false;
 let consentFiredThisSession = false;
@@ -33,8 +49,18 @@ let consentFiredThisSession = false;
  * and reference outer scope — none of which works when a callback is
  * serialized with `Function.prototype.toString`.
  */
-function emit(type: typeof CONSENT_EVENT | typeof CHANGE_EVENT, state: ConsentState): void {
+function emit(
+  type: typeof CONSENT_EVENT | typeof CHANGE_EVENT,
+  state: ConsentState,
+  debug?: boolean,
+): void {
+  log(debug, `emit ${type}`, state);
   document.dispatchEvent(new CustomEvent(type, { detail: state }));
+}
+
+function persist(state: ConsentState, debug?: boolean): void {
+  log(debug, `localStorage write (${getStorageKey()})`, state);
+  writeConsent(state);
 }
 
 export function initConsentManager(config: SerializableConsentConfig): void {
@@ -50,15 +76,23 @@ export function initConsentManager(config: SerializableConsentConfig): void {
   // Inject banner + modal DOM (idempotent).
   injectUI(config, text);
 
+  const initialState = readConsent();
+  const initialNeeds = needsConsent(config.version, config.maxAgeDays);
+  log(
+    config.debug,
+    `init — version: ${config.version}, locale: ${JSON.stringify(resolveLocale(config))}, consent: ${initialState ? 'stored' : 'null'}${initialNeeds ? ' (needs consent)' : ''}`,
+    { state: initialState },
+  );
+
   // Check consent state.
-  if (needsConsent(config.version, config.maxAgeDays)) {
+  if (initialNeeds) {
+    log(config.debug, 'banner shown');
     showBanner();
   } else if (!consentFiredThisSession) {
     // Fire the consent event once per session (not on every SPA navigation).
     consentFiredThisSession = true;
-    const existing = readConsent();
-    if (existing) {
-      emit(CONSENT_EVENT, existing);
+    if (initialState) {
+      emit(CONSENT_EVENT, initialState, config.debug);
     }
   }
 
@@ -75,23 +109,25 @@ export function initConsentManager(config: SerializableConsentConfig): void {
       switch (action) {
         case 'accept-all':
         case 'modal-accept-all': {
+          log(config.debug, `${action} →`, 'all categories: true');
           const state = acceptAll(config);
-          writeConsent(state);
+          persist(state, config.debug);
           hideBanner();
           hideModal();
           consentFiredThisSession = true;
-          emit(CONSENT_EVENT, state);
+          emit(CONSENT_EVENT, state, config.debug);
           break;
         }
 
         case 'reject-all':
         case 'modal-reject-all': {
+          log(config.debug, `${action} →`, 'non-essential categories: false');
           const state = rejectAll(config);
-          writeConsent(state);
+          persist(state, config.debug);
           hideBanner();
           hideModal();
           consentFiredThisSession = true;
-          emit(CONSENT_EVENT, state);
+          emit(CONSENT_EVENT, state, config.debug);
           break;
         }
 
@@ -116,11 +152,12 @@ export function initConsentManager(config: SerializableConsentConfig): void {
         case 'save-preferences': {
           const selections = getModalSelections();
           const isUpdate = !needsConsent(config.version, config.maxAgeDays);
+          log(config.debug, `save-preferences →`, selections, isUpdate ? '(update)' : '(initial)');
           const state = savePreferences(config, selections);
-          writeConsent(state);
+          persist(state, config.debug);
           hideModal();
           consentFiredThisSession = true;
-          emit(isUpdate ? CHANGE_EVENT : CONSENT_EVENT, state);
+          emit(isUpdate ? CHANGE_EVENT : CONSENT_EVENT, state, config.debug);
           break;
         }
 
@@ -196,18 +233,20 @@ export function initConsentManager(config: SerializableConsentConfig): void {
         timestamp: Date.now(),
         categories: baseCategories,
       };
-      writeConsent(state);
+      log(config.debug, 'api.set →', categories);
+      persist(state, config.debug);
       // If this is the first consent record, the banner should disappear and
       // a CONSENT_EVENT should fire (not CHANGE_EVENT).
       if (!current) {
         hideBanner();
         consentFiredThisSession = true;
-        emit(CONSENT_EVENT, state);
+        emit(CONSENT_EVENT, state, config.debug);
       } else {
-        emit(CHANGE_EVENT, state);
+        emit(CHANGE_EVENT, state, config.debug);
       }
     },
     reset: () => {
+      log(config.debug, 'api.reset — clearing stored consent');
       clearConsent();
       injectUI(config, text);
       showBanner();
@@ -232,6 +271,32 @@ export function initConsentManager(config: SerializableConsentConfig): void {
       showModal();
     },
   };
+
+  if (config.debug) {
+    api.debug = (): ConsentDebugSnapshot => {
+      const state = readConsent();
+      const snapshot: ConsentDebugSnapshot = {
+        config,
+        resolvedLocale: resolveLocale(config),
+        resolvedText: text as unknown as Record<string, unknown>,
+        storageKey: getStorageKey(),
+        state,
+        versionMatch: state ? state.version === config.version : false,
+        needsConsent: needsConsent(config.version, config.maxAgeDays),
+      };
+      // eslint-disable-next-line no-console
+      console.group(`${LOG_PREFIX} debug snapshot`);
+      console.log('config', snapshot.config);
+      console.log('resolvedLocale', snapshot.resolvedLocale);
+      console.log('resolvedText', snapshot.resolvedText);
+      console.log('storageKey', snapshot.storageKey);
+      console.log('state', snapshot.state);
+      console.log('versionMatch', snapshot.versionMatch);
+      console.log('needsConsent', snapshot.needsConsent);
+      console.groupEnd();
+      return snapshot;
+    };
+  }
 
   window.astroConsent = api;
   window.zdenekkureckaConsent = api;

--- a/packages/astro-consent/src/consent.ts
+++ b/packages/astro-consent/src/consent.ts
@@ -7,6 +7,10 @@ export function setStorageKey(key: string | undefined): void {
   STORAGE_KEY = key || DEFAULT_STORAGE_KEY;
 }
 
+export function getStorageKey(): string {
+  return STORAGE_KEY;
+}
+
 export function readConsent(): ConsentState | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);

--- a/packages/astro-consent/src/integration.ts
+++ b/packages/astro-consent/src/integration.ts
@@ -9,6 +9,7 @@ export default function cookieConsent(userConfig: ConsentConfig): AstroIntegrati
     cookiePolicy: userConfig.cookiePolicy,
     storageKey: userConfig.storageKey,
     maxAgeDays: userConfig.maxAgeDays,
+    debug: userConfig.debug,
     text: userConfig.text,
     localeText: userConfig.localeText,
   };

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -66,6 +66,17 @@ export interface ConsentConfig {
    */
   maxAgeDays?: number;
 
+  /**
+   * Enables verbose `console.debug` logging of runtime events (init, banner
+   * show, accept/reject/save, event dispatch, storage writes) and exposes
+   * `window.astroConsent.debug()` for an on-demand state dump. Intended for
+   * local development; gate behind `import.meta.env.DEV` so it never ships
+   * to production.
+   *
+   * @default false
+   */
+  debug?: boolean;
+
   /** Single-language text overrides, or shared fallback for `localeText`. */
   text?: ConsentText;
 
@@ -91,8 +102,24 @@ export interface SerializableConsentConfig {
   cookiePolicy?: CookiePolicyLink;
   storageKey?: string;
   maxAgeDays?: number;
+  debug?: boolean;
   text?: ConsentText;
   localeText?: Record<string, ConsentText>;
+}
+
+/**
+ * Snapshot returned by `ConsentAPI.debug()` when `debug: true`. Captures the
+ * fully-resolved runtime state so developers can inspect what the integration
+ * sees without digging through localStorage or reading source.
+ */
+export interface ConsentDebugSnapshot {
+  config: SerializableConsentConfig;
+  resolvedLocale: string | null;
+  resolvedText: Record<string, unknown>;
+  storageKey: string;
+  state: ConsentState | null;
+  versionMatch: boolean;
+  needsConsent: boolean;
 }
 
 export interface ConsentAPI {
@@ -114,6 +141,12 @@ export interface ConsentAPI {
   show(): void;
   /** Open the preferences modal. */
   showPreferences(): void;
+  /**
+   * Dumps a `console.group` with the current config, resolved locale/text,
+   * storage key, and stored state, and returns the same snapshot. Only
+   * attached when the integration is configured with `debug: true`.
+   */
+  debug?(): ConsentDebugSnapshot;
 }
 
 /**

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -74,6 +74,23 @@ function mergeText(base: ResolvedConsentText, layer: ConsentText | undefined): R
  * overrides compose correctly — callers only need to supply the keys they
  * want to change.
  */
+/**
+ * Resolve which entry in `config.localeText` would apply for the current
+ * `<html lang>`, returning the tag that matched (exact or primary subtag), or
+ * `null` if there is no match / no localeText configured. Used by the debug
+ * helper so developers can see why a particular string layer was picked.
+ */
+export function resolveLocale(config: SerializableConsentConfig): string | null {
+  const localeText = config.localeText;
+  if (!localeText) return null;
+  const lang = (document.documentElement.lang || '').trim();
+  if (!lang) return null;
+  if (localeText[lang]) return lang;
+  const primary = lang.split('-')[0];
+  if (primary && primary !== lang && localeText[primary]) return primary;
+  return null;
+}
+
 export function resolveText(config: SerializableConsentConfig): ResolvedConsentText {
   let resolved = mergeText(BUILT_IN_DEFAULTS, config.text);
 


### PR DESCRIPTION
Closes #22.

## Summary
- New `debug?: boolean` config flag threaded through the virtual config module. Gated recommendation: `debug: import.meta.env.DEV`.
- Verbose `console.debug('[astro-consent]', …)` logging at init, banner show, accept/reject/save clicks, `api.set` / `api.reset`, event dispatch, and localStorage writes. Uses `console.debug` so it's filterable and defaults to hidden unless DevTools log level includes Verbose.
- New `window.astroConsent.debug()` helper (optional on `ConsentAPI`) that `console.group`s and returns a `ConsentDebugSnapshot`: config, resolved locale, resolved text, storage key, stored state, `versionMatch`, `needsConsent`. Only attached when `debug: true`, so production bundles stay clean.
- Docs: new "Debug mode" how-to in the README, plus the new fields added to the `ConsentConfig` and `ConsentAPI` reference blocks.

Visual dev badge intentionally deferred to a follow-up, matching the issue's "can be a follow-up" note.

## Test plan
- [ ] `pnpm --filter @zdenekkurecka/astro-consent build` passes
- [ ] Set `debug: true` in `playground/astro.config.mjs`, run `pnpm --filter playground dev`
- [ ] Open DevTools → set log level to include **Verbose**
- [ ] Confirm `[astro-consent] init — version: 1, locale: …` logs on load
- [ ] Click accept-all / reject-all / manage → save, confirm each action logs with the storage write and emitted event
- [ ] Call `astroConsent.debug()` in the console, confirm the grouped snapshot appears and returns the object
- [ ] Flip `debug: false`, reload, confirm zero `[astro-consent]` output and that `astroConsent.debug` is `undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)