### PR TITLE
feat(consent): support astro add with clear error on missing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ they force you to serialize your tracker callbacks into a JSON config.
 
 ## Installation
 
+The recommended way is to use Astro's integration installer, which adds the
+package and wires it into `astro.config.*` in one step:
+
+```sh
+# pnpm
+pnpm astro add @zdenekkurecka/astro-consent
+# npm
+npx astro add @zdenekkurecka/astro-consent
+# yarn
+yarn astro add @zdenekkurecka/astro-consent
+```
+
+> **Heads up:** `cookieConsent()` requires at least `version` and `categories`.
+> `astro add` inserts a bare `cookieConsent()` call — open `astro.config.*`
+> after it runs and pass the required options shown in [Quick start](#quick-start).
+> You'll get a clear error at build time if you forget.
+
+Or install manually:
+
 ```sh
 # pnpm
 pnpm add @zdenekkurecka/astro-consent

--- a/packages/astro-consent/src/integration.ts
+++ b/packages/astro-consent/src/integration.ts
@@ -2,7 +2,17 @@ import type { AstroIntegration } from 'astro';
 import type { ConsentConfig, SerializableConsentConfig } from './types.js';
 import { vitePluginConsentConfig } from './virtual-config.js';
 
-export default function cookieConsent(userConfig: ConsentConfig): AstroIntegration {
+export default function cookieConsent(userConfig?: ConsentConfig): AstroIntegration {
+  if (!userConfig || typeof userConfig.version !== 'number' || !userConfig.categories) {
+    throw new Error(
+      '[@zdenekkurecka/astro-consent] Missing required config. ' +
+        '`cookieConsent()` requires a `version` (number) and a `categories` map. ' +
+        'If you used `astro add`, open astro.config.* and replace `cookieConsent()` with a call that passes at least ' +
+        '`{ version: 1, categories: { analytics: { label: "Analytics", description: "…", default: false } } }`. ' +
+        'See https://github.com/zdenekkurecka/astro-consent#quick-start',
+    );
+  }
+
   const serializableConfig: SerializableConsentConfig = {
     version: userConfig.version,
     categories: userConfig.categories,


### PR DESCRIPTION
Closes #33

## Summary
- Make `cookieConsent()`'s argument optional and throw a clear, actionable error when `version` or `categories` are missing — so users who run `npx astro add @zdenekkurecka/astro-consent` (which injects a bare `cookieConsent()` call) get a helpful message pointing to Quick start instead of a cryptic `undefined` access.
- Promote `astro add` as the primary install path in both the root README and the published package README, with a heads-up note about the required config.

## Test plan
- [x] `pnpm --filter @zdenekkurecka/astro-consent build` passes
- [ ] Manual end-to-end: run `npx astro add @zdenekkurecka/astro-consent` in a fresh Astro app, confirm the injected call throws the new error, then add `version` + `categories` and confirm the integration boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
