### PR TITLE
refactor(consent): address PR #46-51 review nits

### DIFF
--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -33,8 +33,10 @@ import {
 
 const LOG_PREFIX = '[astro-consent]';
 
-function log(enabled: boolean | undefined, ...args: unknown[]): void {
-  if (!enabled) return;
+let debugEnabled = false;
+
+function log(...args: unknown[]): void {
+  if (!debugEnabled) return;
   // console.debug is filterable separately from .log in DevTools and is
   // stripped by default in Chrome's standard log level.
   console.debug(LOG_PREFIX, ...args);
@@ -53,18 +55,19 @@ let consentFiredThisSession = false;
 function emit(
   type: typeof CONSENT_EVENT | typeof CHANGE_EVENT,
   state: ConsentState,
-  debug?: boolean,
 ): void {
-  log(debug, `emit ${type}`, state);
+  log(`emit ${type}`, state);
   document.dispatchEvent(new CustomEvent(type, { detail: state }));
 }
 
-function persist(state: ConsentState, debug?: boolean): void {
-  log(debug, `localStorage write (${getStorageKey()})`, state);
+function persist(state: ConsentState): void {
+  log(`localStorage write (${getStorageKey()})`, state);
   writeConsent(state);
 }
 
 export function initConsentManager(config: SerializableConsentConfig): void {
+  debugEnabled = config.debug === true;
+
   // Apply the configured localStorage key before any read/write so multiple
   // Astro apps on the same origin don't clobber each other's consent state.
   setStorageKey(config.storageKey);
@@ -80,20 +83,19 @@ export function initConsentManager(config: SerializableConsentConfig): void {
   const initialState = readConsent();
   const initialNeeds = needsConsent(config.version, config.maxAgeDays);
   log(
-    config.debug,
     `init — version: ${config.version}, locale: ${JSON.stringify(resolveLocale(config))}, consent: ${initialState ? 'stored' : 'null'}${initialNeeds ? ' (needs consent)' : ''}`,
     { state: initialState },
   );
 
   // Check consent state.
   if (initialNeeds) {
-    log(config.debug, 'banner shown');
+    log('banner shown');
     showBanner();
   } else if (!consentFiredThisSession) {
     // Fire the consent event once per session (not on every SPA navigation).
     consentFiredThisSession = true;
     if (initialState) {
-      emit(CONSENT_EVENT, initialState, config.debug);
+      emit(CONSENT_EVENT, initialState);
     }
   }
 
@@ -110,25 +112,25 @@ export function initConsentManager(config: SerializableConsentConfig): void {
       switch (action) {
         case 'accept-all':
         case 'modal-accept-all': {
-          log(config.debug, `${action} →`, 'all categories: true');
+          log(`${action} →`, 'all categories: true');
           const state = acceptAll(config);
-          persist(state, config.debug);
+          persist(state);
           hideBanner();
           hideModal();
           consentFiredThisSession = true;
-          emit(CONSENT_EVENT, state, config.debug);
+          emit(CONSENT_EVENT, state);
           break;
         }
 
         case 'reject-all':
         case 'modal-reject-all': {
-          log(config.debug, `${action} →`, 'non-essential categories: false');
+          log(`${action} →`, 'non-essential categories: false');
           const state = rejectAll(config);
-          persist(state, config.debug);
+          persist(state);
           hideBanner();
           hideModal();
           consentFiredThisSession = true;
-          emit(CONSENT_EVENT, state, config.debug);
+          emit(CONSENT_EVENT, state);
           break;
         }
 
@@ -153,12 +155,12 @@ export function initConsentManager(config: SerializableConsentConfig): void {
         case 'save-preferences': {
           const selections = getModalSelections();
           const isUpdate = !needsConsent(config.version, config.maxAgeDays);
-          log(config.debug, `save-preferences →`, selections, isUpdate ? '(update)' : '(initial)');
+          log(`save-preferences →`, selections, isUpdate ? '(update)' : '(initial)');
           const state = savePreferences(config, selections);
-          persist(state, config.debug);
+          persist(state);
           hideModal();
           consentFiredThisSession = true;
-          emit(isUpdate ? CHANGE_EVENT : CONSENT_EVENT, state, config.debug);
+          emit(isUpdate ? CHANGE_EVENT : CONSENT_EVENT, state);
           break;
         }
 
@@ -234,20 +236,20 @@ export function initConsentManager(config: SerializableConsentConfig): void {
         timestamp: Date.now(),
         categories: baseCategories,
       };
-      log(config.debug, 'api.set →', categories);
-      persist(state, config.debug);
+      log('api.set →', categories);
+      persist(state);
       // If this is the first consent record, the banner should disappear and
       // a CONSENT_EVENT should fire (not CHANGE_EVENT).
       if (!current) {
         hideBanner();
         consentFiredThisSession = true;
-        emit(CONSENT_EVENT, state, config.debug);
+        emit(CONSENT_EVENT, state);
       } else {
-        emit(CHANGE_EVENT, state, config.debug);
+        emit(CHANGE_EVENT, state);
       }
     },
     reset: () => {
-      log(config.debug, 'api.reset — clearing stored consent');
+      log('api.reset — clearing stored consent');
       clearConsent();
       injectUI(config, text);
       showBanner();
@@ -260,7 +262,7 @@ export function initConsentManager(config: SerializableConsentConfig): void {
       // Make sure the container exists so the attribute has somewhere to
       // live on first call (e.g. before the banner has ever been shown).
       injectUI(config, text);
-      log(config.debug, `api.setTheme →`, mode);
+      log(`api.setTheme →`, mode);
       setContainerTheme(mode);
     },
     showPreferences: () => {

--- a/packages/astro-consent/src/integration.ts
+++ b/packages/astro-consent/src/integration.ts
@@ -3,10 +3,16 @@ import type { ConsentConfig, SerializableConsentConfig } from './types.js';
 import { vitePluginConsentConfig } from './virtual-config.js';
 
 export default function cookieConsent(userConfig?: ConsentConfig): AstroIntegration {
-  if (!userConfig || typeof userConfig.version !== 'number' || !userConfig.categories) {
+  if (
+    !userConfig ||
+    typeof userConfig.version !== 'number' ||
+    !userConfig.categories ||
+    typeof userConfig.categories !== 'object' ||
+    Object.keys(userConfig.categories).length === 0
+  ) {
     throw new Error(
       '[@zdenekkurecka/astro-consent] Missing required config. ' +
-        '`cookieConsent()` requires a `version` (number) and a `categories` map. ' +
+        '`cookieConsent()` requires a `version` (number) and a non-empty `categories` map. ' +
         'If you used `astro add`, open astro.config.* and replace `cookieConsent()` with a call that passes at least ' +
         '`{ version: 1, categories: { analytics: { label: "Analytics", description: "…", default: false } } }`. ' +
         'See https://github.com/zdenekkurecka/astro-consent#quick-start',

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -66,15 +66,6 @@ function mergeText(base: ResolvedConsentText, layer: ConsentText | undefined): R
 }
 
 /**
- * Resolve the UI text layers for the current document.
- *
- * Reads `document.documentElement.lang`, picks the best match from
- * `config.localeText` (exact tag → primary subtag), and deep-merges the
- * layers: built-in defaults → `config.text` → resolved locale entry. Partial
- * overrides compose correctly — callers only need to supply the keys they
- * want to change.
- */
-/**
  * Resolve which entry in `config.localeText` would apply for the current
  * `<html lang>`, returning the tag that matched (exact or primary subtag), or
  * `null` if there is no match / no localeText configured. Used by the debug
@@ -91,6 +82,15 @@ export function resolveLocale(config: SerializableConsentConfig): string | null 
   return null;
 }
 
+/**
+ * Resolve the UI text layers for the current document.
+ *
+ * Reads `document.documentElement.lang`, picks the best match from
+ * `config.localeText` (exact tag → primary subtag), and deep-merges the
+ * layers: built-in defaults → `config.text` → resolved locale entry. Partial
+ * overrides compose correctly — callers only need to supply the keys they
+ * want to change.
+ */
 export function resolveText(config: SerializableConsentConfig): ResolvedConsentText {
   let resolved = mergeText(BUILT_IN_DEFAULTS, config.text);
 


### PR DESCRIPTION
## Summary
Follow-up cleanup from a code review of PRs #46–51. No behavior changes in the happy path.

- **`ui.ts`** — Move the orphaned `resolveText` JSDoc block back above `resolveText`. PR #49 inserted `resolveLocale` between the doc comment and its function, stranding the block as a dangling comment above the wrong function.
- **`integration.ts`** — Tighten the validation guard in `cookieConsent()` so `categories: {}` (or a non-object value) also throws the helpful missing-config error instead of booting with an empty category map.
- **`client.ts`** — Hoist the debug flag to a module-level `debugEnabled` set once in `initConsentManager`. Drops the `debug?: boolean` parameter from `log`/`emit`/`persist` and removes 10+ redundant call-site arguments, matching the existing `setStorageKey` pattern.

## Test plan
- [x] `pnpm --filter @zdenekkurecka/astro-consent build` passes (tsc typecheck + copy assets)
- [x] Playground: `debug: true` still emits `[astro-consent]` debug logs at every lifecycle point
- [x] Playground: `debug: false` / unset still produces zero debug output
- [ ] Manual: `cookieConsent({ version: 1, categories: {} })` now throws the helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)