### PR TITLE
chore: revert manual 0.2.0 bump so changesets can reclaim it

### DIFF
--- a/packages/astro-consent/package.json
+++ b/packages/astro-consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zdenekkurecka/astro-consent",
-  "version": "0.2.0",
+  "version": "0.1.3",
   "description": "Astro integration for GDPR/ePrivacy-friendly cookie consent: banner, preferences modal, runtime API, category-based consent state, strict-CSP safe, works with or without View Transitions.",
   "keywords": [
     "astro",


### PR DESCRIPTION
## Summary
- Reverts `packages/astro-consent/package.json` from `0.2.0` → `0.1.3` so the changesets release workflow computes `0.1.3 + minor = 0.2.0` for the pending `storageKey` and `maxAgeDays` changesets.
- `0.2.0` was manually set in ef3c06a but never published to npm (latest on npm is `0.1.3`), so no version is lost.
- Aligns the release with the existing 0.2.0 milestone.

## Test plan
- [ ] After merge, the publish workflow opens a new release PR titled `chore(release): version packages` bumping to **0.2.0**.
- [ ] Merging that PR publishes `@zdenekkurecka/astro-consent@0.2.0` to npm.