### PR TITLE
ci(release): rename tags and releases to astro-consent-vX.Y.Z style

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,45 @@ jobs:
           publish: pnpm release
           title: 'chore(release): version packages'
           commit: 'chore(release): version packages'
-          createGithubReleases: true
+          # We create tags + GitHub Releases ourselves in the next step so the
+          # naming matches the legacy `astro-consent-vX.Y.Z` style instead of
+          # the monorepo-default `@zdenekkurecka/astro-consent@X.Y.Z`.
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
+
+      - name: Rename tags and create GitHub Releases
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          set -euo pipefail
+          echo "$PUBLISHED_PACKAGES" | jq -c '.[]' | while read -r pkg; do
+            name=$(echo "$pkg" | jq -r '.name')
+            version=$(echo "$pkg" | jq -r '.version')
+            short="${name##*/}"
+            new_tag="${short}-v${version}"
+            old_tag="${name}@${version}"
+
+            echo "Renaming $old_tag → $new_tag"
+
+            # Create the pretty tag on the same commit and push it.
+            git tag "$new_tag" "$old_tag"
+            git push origin "refs/tags/$new_tag"
+
+            # Remove the ugly tag from origin (local copy is ephemeral).
+            git push origin ":refs/tags/$old_tag" || true
+
+            # Extract just this version's section from the package CHANGELOG.
+            notes=$(awk -v ver="$version" '
+              $0 == "## " ver { inblock = 1; next }
+              inblock && /^## / { exit }
+              inblock { print }
+            ' "packages/${short}/CHANGELOG.md")
+
+            gh release create "$new_tag" \
+              --title "$new_tag" \
+              --notes "$notes"
+          done


### PR DESCRIPTION
## Summary
- Disables the changesets/action built-in GitHub Release creation (`createGithubReleases: false`).
- Adds a follow-up step that, for every entry in `steps.changesets.outputs.publishedPackages`, creates a `astro-consent-vX.Y.Z` tag on the same commit, pushes it, deletes the `@zdenekkurecka/astro-consent@X.Y.Z` tag from origin, and runs `gh release create` with notes extracted from `packages/astro-consent/CHANGELOG.md` for that version.
- Matches the legacy tag/release style (`astro-consent-v0.1.1` … `v0.1.3`).

The existing `@zdenekkurecka/astro-consent@0.2.0` tag and release have already been renamed manually to `astro-consent-v0.2.0` so history is uniform.

## Test plan
- [ ] Next release cycle produces a tag named `astro-consent-vX.Y.Z` on the release commit.
- [ ] Corresponding GitHub Release appears with the matching name and CHANGELOG-derived notes.
- [ ] No `@zdenekkurecka/astro-consent@X.Y.Z` tag remains on origin after the workflow finishes.
- [ ] npm publish + provenance still work (Trusted Publishing path is unchanged).
