### PR TITLE
Release v0.2.1: fix modal backdrop click + e2e coverage

### DIFF
--- a/.changeset/fix-modal-backdrop-click.md
+++ b/.changeset/fix-modal-backdrop-click.md
@@ -1,0 +1,5 @@
+---
+"@zdenekkurecka/astro-consent": patch
+---
+
+Fix preferences modal not closing when clicking the dimmed backdrop. The `.cc-modal` wrapper spans the full viewport above `.cc-overlay`, so real user clicks on the dimmed area always landed on `#cc-modal` — never on `#cc-overlay` — and the close handler never fired. The handler now matches `#cc-modal` as the click target, and the Playwright coverage was updated to click the backdrop positionally instead of dispatching on the overlay element.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: Playwright (chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.8.1
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: pnpm test
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,12 @@ vite.config.ts.timestamp-*
 # Astro
 .astro/
 
+# Playwright
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+
 # Claude Code — personal/local settings (team config would go in .claude/settings.json)
 .claude/settings.local.json
 

--- a/package.json
+++ b/package.json
@@ -7,14 +7,22 @@
     "build:all": "pnpm -r build",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "pnpm --filter @zdenekkurecka/astro-consent build && changeset publish"
+    "release": "pnpm --filter @zdenekkurecka/astro-consent build && changeset publish",
+    "test": "playwright test",
+    "test:ui": "playwright test --ui",
+    "test:chromium": "playwright test --project=chromium"
   },
   "packageManager": "pnpm@10.8.1",
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",
-    "@changesets/cli": "^2.27.9"
+    "@changesets/cli": "^2.27.9",
+    "@playwright/test": "^1.59.1"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["@parcel/watcher", "esbuild", "sharp"]
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "esbuild",
+      "sharp"
+    ]
   }
 }

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -184,9 +184,12 @@ export function initConsentManager(config: SerializableConsentConfig): void {
       }
     });
 
-    // Close modal on overlay click.
+    // Close modal on backdrop click. The `.cc-modal` wrapper spans the full
+    // viewport and sits above `.cc-overlay`, so a click on the dimmed area
+    // lands on `#cc-modal` itself rather than `#cc-overlay`. Clicks inside
+    // `.cc-modal-inner` bubble up with a different target and are ignored.
     document.addEventListener('click', (e) => {
-      if ((e.target as HTMLElement).id === 'cc-overlay') {
+      if ((e.target as HTMLElement).id === 'cc-modal') {
         hideModal();
         if (needsConsent(config.version, config.maxAgeDays)) {
           showBanner();

--- a/playground/e2e/banner.spec.ts
+++ b/playground/e2e/banner.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { clearConsent, expectBannerVisible } from './helpers';
+
+test.describe('Banner', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await clearConsent(page);
+    await page.reload();
+  });
+
+  test('shows banner on first visit (no stored consent)', async ({ page }) => {
+    await expectBannerVisible(page, true);
+  });
+
+  test('banner has accept, reject, and manage buttons', async ({ page }) => {
+    await expect(page.locator('[data-cc=accept-all]')).toBeVisible();
+    await expect(page.locator('[data-cc=reject-all]')).toBeVisible();
+    await expect(page.locator('[data-cc=manage]')).toBeVisible();
+  });
+
+  test('banner does not show when valid consent exists', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+    await page.reload();
+    await expectBannerVisible(page, false);
+  });
+
+  test('cookie policy link is rendered', async ({ page }) => {
+    const link = page.locator('.cc-banner .cc-policy-link');
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('href', '/cookie-policy');
+    await expect(link).toHaveText('Cookie Policy');
+  });
+});

--- a/playground/e2e/consent-state.spec.ts
+++ b/playground/e2e/consent-state.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import {
+  clearConsent,
+  expectBannerVisible,
+  getConsentState,
+  getConsentAPI,
+} from './helpers';
+
+test.describe('Consent state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await clearConsent(page);
+    await page.reload();
+  });
+
+  test('accept all → all categories true', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+
+    const state = await getConsentState(page);
+    expect(state).not.toBeNull();
+    expect(state.version).toBe(1);
+    expect(state.categories.essential).toBe(true);
+    expect(state.categories.analytics).toBe(true);
+    expect(state.categories.marketing).toBe(true);
+    expect(state.timestamp).toBeGreaterThan(0);
+
+    await expectBannerVisible(page, false);
+  });
+
+  test('reject all → non-essential categories false', async ({ page }) => {
+    await page.locator('[data-cc=reject-all]').click();
+
+    const state = await getConsentState(page);
+    expect(state.categories.essential).toBe(true);
+    expect(state.categories.analytics).toBe(false);
+    expect(state.categories.marketing).toBe(false);
+
+    await expectBannerVisible(page, false);
+  });
+
+  test('save preferences → respects individual toggles', async ({ page }) => {
+    await page.locator('[data-cc=manage]').click();
+
+    // The real inputs are visually hidden (width/height: 0) so Playwright's
+    // check()/uncheck() can't target them directly. Click the wrapping
+    // <label class="cc-toggle"> which toggles the input.
+    await page.locator('label.cc-toggle:has([data-cc-category=analytics])').click();
+    // Marketing default is false, so nothing to uncheck — ensure it stays off
+    // by reading the checkbox state without touching it.
+    await expect(page.locator('[data-cc-category=marketing]')).not.toBeChecked();
+
+    await page.locator('[data-cc=save-preferences]').click();
+
+    const state = await getConsentState(page);
+    expect(state.categories.essential).toBe(true);
+    expect(state.categories.analytics).toBe(true);
+    expect(state.categories.marketing).toBe(false);
+  });
+
+  test('essential toggle is always checked and disabled', async ({ page }) => {
+    await page.locator('[data-cc=manage]').click();
+    const essential = page.locator('[data-cc-category=essential]');
+    await expect(essential).toBeChecked();
+    await expect(essential).toBeDisabled();
+  });
+
+  test('runtime API matches localStorage', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+
+    const fromStorage = await getConsentState(page);
+    const fromAPI = await getConsentAPI(page);
+
+    expect(fromAPI).toEqual(fromStorage);
+  });
+});

--- a/playground/e2e/events.spec.ts
+++ b/playground/e2e/events.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+import { clearConsent } from './helpers';
+
+test.describe('Events', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await clearConsent(page);
+    await page.reload();
+  });
+
+  test('astro-consent:consent fires on accept-all', async ({ page }) => {
+    const eventPromise = page.evaluate(
+      () =>
+        new Promise<any>((resolve) => {
+          document.addEventListener(
+            'astro-consent:consent',
+            (e: any) => resolve(e.detail),
+            { once: true },
+          );
+        }),
+    );
+
+    await page.locator('[data-cc=accept-all]').click();
+
+    const detail = await eventPromise;
+    expect(detail.version).toBe(1);
+    expect(detail.categories.analytics).toBe(true);
+  });
+
+  test('astro-consent:consent fires on page load with existing consent', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+
+    // Register listener before the next navigation so we catch the event
+    // fired during init on the fresh page.
+    await page.addInitScript(() => {
+      (window as any).__consentEventDetail = null;
+      document.addEventListener(
+        'astro-consent:consent',
+        (e: any) => {
+          (window as any).__consentEventDetail = e.detail;
+        },
+        { once: true },
+      );
+    });
+
+    await page.goto('/about');
+
+    await expect
+      .poll(async () => page.evaluate(() => (window as any).__consentEventDetail))
+      .not.toBeNull();
+
+    const detail = await page.evaluate(() => (window as any).__consentEventDetail);
+    expect(detail.version).toBe(1);
+    expect(detail.categories.analytics).toBe(true);
+  });
+
+  test('astro-consent:change fires when updating preferences', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+
+    const changePromise = page.evaluate(
+      () =>
+        new Promise<any>((resolve) => {
+          document.addEventListener(
+            'astro-consent:change',
+            (e: any) => resolve(e.detail),
+            { once: true },
+          );
+        }),
+    );
+
+    await page.evaluate(() => window.astroConsent?.showPreferences());
+    // Hidden input — click the wrapping label to toggle it off.
+    await page.locator('label.cc-toggle:has([data-cc-category=marketing])').click();
+    await page.locator('[data-cc=save-preferences]').click();
+
+    const detail = await changePromise;
+    expect(detail.categories.marketing).toBe(false);
+    expect(detail.categories.analytics).toBe(true);
+  });
+});

--- a/playground/e2e/helpers.ts
+++ b/playground/e2e/helpers.ts
@@ -1,0 +1,49 @@
+import { type Page, expect } from '@playwright/test';
+
+export async function clearConsent(page: Page) {
+  await page.evaluate(() => localStorage.removeItem('astro-consent'));
+}
+
+export async function getConsentState(page: Page) {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem('astro-consent');
+    return raw ? JSON.parse(raw) : null;
+  });
+}
+
+export async function getConsentAPI(page: Page) {
+  return page.evaluate(() => window.astroConsent?.get() ?? null);
+}
+
+export async function waitForConsentEvent(
+  page: Page,
+  event: 'astro-consent:consent' | 'astro-consent:change',
+) {
+  return page.evaluate((evt) => {
+    return new Promise<any>((resolve) => {
+      document.addEventListener(evt, (e: any) => resolve(e.detail), { once: true });
+    });
+  }, event);
+}
+
+export async function expectBannerVisible(page: Page, visible = true) {
+  const banner = page.locator('#cc-banner');
+  if (visible) {
+    await expect(banner).toHaveClass(/cc-visible/);
+    await expect(banner).toHaveAttribute('aria-hidden', 'false');
+  } else {
+    await expect(banner).not.toHaveClass(/cc-visible/);
+    await expect(banner).toHaveAttribute('aria-hidden', 'true');
+  }
+}
+
+export async function expectModalVisible(page: Page, visible = true) {
+  const modal = page.locator('#cc-modal');
+  if (visible) {
+    await expect(modal).toHaveClass(/cc-visible/);
+    await expect(modal).toHaveAttribute('aria-hidden', 'false');
+  } else {
+    await expect(modal).not.toHaveClass(/cc-visible/);
+    await expect(modal).toHaveAttribute('aria-hidden', 'true');
+  }
+}

--- a/playground/e2e/modal.spec.ts
+++ b/playground/e2e/modal.spec.ts
@@ -30,15 +30,13 @@ test.describe('Preferences modal', () => {
     await expectModalVisible(page, false);
   });
 
-  test('overlay click closes modal', async ({ page }) => {
+  test('backdrop click closes modal', async ({ page }) => {
     await page.locator('[data-cc=manage]').click();
     await expectModalVisible(page, true);
 
-    // The .cc-modal element fully covers the viewport and sits above
-    // .cc-overlay in the z-stack, so a real viewport click lands on the
-    // modal. Dispatch the click directly on the overlay element so the
-    // handler's `e.target.id === 'cc-overlay'` check fires.
-    await page.evaluate(() => document.getElementById('cc-overlay')?.click());
+    // Click the dimmed area outside .cc-modal-inner. .cc-modal spans the
+    // full viewport, so a click near the corner lands on the backdrop.
+    await page.locator('#cc-modal').click({ position: { x: 5, y: 5 } });
     await expectModalVisible(page, false);
   });
 

--- a/playground/e2e/modal.spec.ts
+++ b/playground/e2e/modal.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import { clearConsent, expectBannerVisible, expectModalVisible } from './helpers';
+
+test.describe('Preferences modal', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await clearConsent(page);
+    await page.reload();
+  });
+
+  test('manage button opens modal and hides banner', async ({ page }) => {
+    await page.locator('[data-cc=manage]').click();
+    await expectModalVisible(page, true);
+    await expectBannerVisible(page, false);
+  });
+
+  test('close button closes modal', async ({ page }) => {
+    await page.locator('[data-cc=manage]').click();
+    await expectModalVisible(page, true);
+
+    await page.locator('[data-cc=close-modal]').click();
+    await expectModalVisible(page, false);
+  });
+
+  test('Escape key closes modal', async ({ page }) => {
+    await page.locator('[data-cc=manage]').click();
+    await expectModalVisible(page, true);
+
+    await page.keyboard.press('Escape');
+    await expectModalVisible(page, false);
+  });
+
+  test('overlay click closes modal', async ({ page }) => {
+    await page.locator('[data-cc=manage]').click();
+    await expectModalVisible(page, true);
+
+    // The .cc-modal element fully covers the viewport and sits above
+    // .cc-overlay in the z-stack, so a real viewport click lands on the
+    // modal. Dispatch the click directly on the overlay element so the
+    // handler's `e.target.id === 'cc-overlay'` check fires.
+    await page.evaluate(() => document.getElementById('cc-overlay')?.click());
+    await expectModalVisible(page, false);
+  });
+
+  test('closing modal without consent re-shows banner', async ({ page }) => {
+    await page.locator('[data-cc=manage]').click();
+    await page.keyboard.press('Escape');
+    await expectBannerVisible(page, true);
+  });
+
+  test('modal has correct ARIA attributes', async ({ page }) => {
+    await page.locator('[data-cc=manage]').click();
+    const modal = page.locator('#cc-modal');
+    await expect(modal).toHaveAttribute('role', 'dialog');
+    await expect(modal).toHaveAttribute('aria-modal', 'true');
+    await expect(modal).toHaveAttribute('aria-labelledby', 'cc-modal-title');
+  });
+
+  test('modal accept-all works same as banner accept-all', async ({ page }) => {
+    await page.locator('[data-cc=manage]').click();
+    await page.locator('[data-cc=modal-accept-all]').click();
+
+    await expectModalVisible(page, false);
+    const state = await page.evaluate(() => {
+      const raw = localStorage.getItem('astro-consent');
+      return raw ? JSON.parse(raw) : null;
+    });
+    expect(state.categories.analytics).toBe(true);
+    expect(state.categories.marketing).toBe(true);
+  });
+});

--- a/playground/e2e/runtime-api.spec.ts
+++ b/playground/e2e/runtime-api.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { clearConsent, expectBannerVisible, getConsentAPI } from './helpers';
+
+test.describe('Runtime API', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await clearConsent(page);
+    await page.reload();
+  });
+
+  test('get() returns null before consent', async ({ page }) => {
+    const state = await getConsentAPI(page);
+    expect(state).toBeNull();
+  });
+
+  test('set() creates initial consent from defaults', async ({ page }) => {
+    await page.evaluate(() => {
+      window.astroConsent?.set({ analytics: true });
+    });
+
+    const state = await getConsentAPI(page);
+    expect(state).not.toBeNull();
+    expect(state!.categories.analytics).toBe(true);
+    expect(state!.categories.marketing).toBe(false);
+    expect(state!.categories.essential).toBe(true);
+
+    await expectBannerVisible(page, false);
+  });
+
+  test('reset() clears consent and re-shows banner', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+    await expectBannerVisible(page, false);
+
+    await page.evaluate(() => window.astroConsent?.reset());
+
+    const state = await getConsentAPI(page);
+    expect(state).toBeNull();
+    await expectBannerVisible(page, true);
+  });
+
+  test('show() displays the banner', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+    await expectBannerVisible(page, false);
+
+    await page.evaluate(() => window.astroConsent?.show());
+    await expectBannerVisible(page, true);
+  });
+
+  test('showPreferences() opens the modal', async ({ page }) => {
+    await page.evaluate(() => window.astroConsent?.showPreferences());
+    const modal = page.locator('#cc-modal');
+    await expect(modal).toHaveClass(/cc-visible/);
+  });
+});

--- a/playground/e2e/version.spec.ts
+++ b/playground/e2e/version.spec.ts
@@ -1,0 +1,25 @@
+import { test } from '@playwright/test';
+import { clearConsent, expectBannerVisible } from './helpers';
+
+test.describe('Versioned consent', () => {
+  test('banner re-appears when stored version < config version', async ({ page }) => {
+    await page.goto('/');
+    await clearConsent(page);
+    await page.reload();
+
+    await page.locator('[data-cc=accept-all]').click();
+    await expectBannerVisible(page, false);
+
+    await page.evaluate(() => {
+      const raw = localStorage.getItem('astro-consent');
+      if (raw) {
+        const state = JSON.parse(raw);
+        state.version = 0;
+        localStorage.setItem('astro-consent', JSON.stringify(state));
+      }
+    });
+
+    await page.reload();
+    await expectBannerVisible(page, true);
+  });
+});

--- a/playground/e2e/view-transitions.spec.ts
+++ b/playground/e2e/view-transitions.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { clearConsent, expectBannerVisible, getConsentState } from './helpers';
+
+test.describe('View Transitions', () => {
+  test('consent persists across SPA navigation', async ({ page }) => {
+    await page.goto('/');
+    await clearConsent(page);
+    await page.reload();
+
+    await page.locator('[data-cc=accept-all]').click();
+    await expectBannerVisible(page, false);
+
+    await page.locator('nav a[href="/about"]').click();
+    await expect(page).toHaveURL('/about');
+
+    await expectBannerVisible(page, false);
+
+    const state = await getConsentState(page);
+    expect(state).not.toBeNull();
+    expect(state.categories.analytics).toBe(true);
+  });
+
+  test('banner does not re-appear after SPA navigation', async ({ page }) => {
+    await page.goto('/');
+    await clearConsent(page);
+    await page.reload();
+
+    await page.locator('[data-cc=reject-all]').click();
+    await expectBannerVisible(page, false);
+
+    await page.locator('nav a[href="/about"]').click();
+    await expect(page).toHaveURL('/about');
+    await page.locator('nav a[href="/"]').click();
+    await expect(page).toHaveURL('/');
+
+    await expectBannerVisible(page, false);
+  });
+
+  test('banner shows on every page for first-time visitor', async ({ page }) => {
+    await page.goto('/');
+    await clearConsent(page);
+    await page.reload();
+
+    await expectBannerVisible(page, true);
+
+    await page.locator('nav a[href="/about"]').click();
+    await expect(page).toHaveURL('/about');
+
+    await expectBannerVisible(page, true);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './playground/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+
+  webServer: {
+    command: 'pnpm build && pnpm --filter playground preview',
+    port: 4321,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+
+  use: {
+    baseURL: 'http://localhost:4321',
+    trace: 'on-first-retry',
+  },
+
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.9
         version: 2.30.0(@types/node@25.6.0)
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
 
   packages/astro-consent:
     devDependencies:
@@ -475,6 +478,11 @@ packages:
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -957,6 +965,11 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1456,6 +1469,16 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
@@ -2338,6 +2361,10 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
     dependencies:
       '@types/estree': 1.0.8
@@ -2846,6 +2873,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -3529,6 +3559,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   pify@4.0.1: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.9:
     dependencies:


### PR DESCRIPTION
## Summary

- **Fix**: preferences modal now closes when clicking the dimmed backdrop (#61). The `.cc-modal` wrapper spans the full viewport above `.cc-overlay`, so real user clicks always landed on `#cc-modal` and the close handler never fired. Handler now matches `#cc-modal` as the click target.
- **Tests**: Playwright e2e suite from #59/#60 for v0.2 regression coverage, with the backdrop-click test updated to perform a real positional click instead of dispatching on the overlay element.
- **CI**: tag/release rename to astro-consent-vX.Y.Z style (already on dev from #57).

Ships as **v0.2.1** via Changesets once merged.

## Test plan

- [x] pnpm --filter astro-consent build succeeds
- [x] pnpm playwright test modal.spec.ts — 7/7 pass, including backdrop click closes modal
- [ ] CI green on this PR
- [ ] After merge, Version Packages PR opens with 0.2.0 → 0.2.1 bump

Generated with Claude Code
