### PR TITLE
UI review: refined modal, button hierarchy, mobile layout

### DIFF
--- a/.changeset/remove-btn-link.md
+++ b/.changeset/remove-btn-link.md
@@ -1,0 +1,7 @@
+---
+'@zdenekkurecka/astro-consent': minor
+---
+
+Button hierarchy on banner and modal: Accept all and Reject all are now both primary; Manage preferences and Save preferences are secondary. On mobile (≤480px) the two primary actions share the top row and the third button spans full-width below.
+
+Breaking (CSS only): the unused `.cc-btn-link` class has been removed. If you were overriding it, copy the rules into your own stylesheet.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,6 +105,10 @@ jobs:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
           set -euo pipefail
+          # changesets-action pushed the default `@scope/name@version` tags
+          # to origin, but they may not be present in this checkout's local
+          # refs. Fetch them so `git tag <new> <old>` can resolve <old>.
+          git fetch --tags origin
           echo "$PUBLISHED_PACKAGES" | jq -c '.[]' | while read -r pkg; do
             name=$(echo "$pkg" | jq -r '.name')
             version=$(echo "$pkg" | jq -r '.version')

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "pnpm --filter @zdenekkurecka/astro-consent build && pnpm --filter playground dev",
+    "dev": "pnpm --filter @zdenekkurecka/astro-consent build && node scripts/dev-parallel.mjs 'ts=pnpm --filter @zdenekkurecka/astro-consent run dev' 'css=pnpm --filter @zdenekkurecka/astro-consent run dev:css' 'play=pnpm --filter playground dev'",
     "build": "pnpm --filter @zdenekkurecka/astro-consent build && pnpm --filter playground build",
     "build:all": "pnpm -r build",
     "changeset": "changeset",

--- a/packages/astro-consent/package.json
+++ b/packages/astro-consent/package.json
@@ -54,7 +54,8 @@
   "scripts": {
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "pnpm run clean && tsc -p tsconfig.build.json && node scripts/copy-assets.mjs",
-    "dev": "tsc -p tsconfig.build.json --watch",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
+    "dev:css": "node --watch-path=src/styles scripts/copy-assets.mjs",
     "prepublishOnly": "pnpm run build"
   },
   "peerDependencies": {

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -410,3 +410,28 @@
   outline: 2px solid var(--cc-primary);
   outline-offset: 2px;
 }
+
+/* ── Mobile (≤ 480px) ───────────────────────────────────── */
+/* Two actions share the top row; third button spans full-width below. */
+
+@media (max-width: 480px) {
+  .cc-banner-actions,
+  .cc-modal-footer {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+
+  .cc-banner-actions {
+    width: 100%;
+  }
+
+  .cc-banner-actions > :nth-child(3),
+  .cc-modal-footer > :nth-child(3) {
+    grid-column: 1 / -1;
+  }
+
+  .cc-modal-footer [data-cc='save-preferences'] {
+    margin-left: 0;
+  }
+}

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -166,8 +166,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.5rem;
-  border-bottom: 1px solid var(--cc-border);
+  padding: 1.5rem 2.5rem 1rem;
 }
 
 .cc-modal-title {
@@ -212,15 +211,20 @@
   flex-wrap: wrap;
 }
 
+.cc-modal-footer [data-cc="save-preferences"] {
+  margin-left: auto;
+}
+
 /* ── Categories ─────────────────────────────────────────── */
 
 .cc-category {
-  padding: 0.75rem 0;
-  border-bottom: 1px solid var(--cc-border);
+  padding: 0.875rem 1rem;
+  background-color: var(--cc-surface);
+  border-radius: 0.75rem;
 }
 
-.cc-category:last-child {
-  border-bottom: none;
+.cc-category + .cc-category {
+  margin-top: 0.5rem;
 }
 
 .cc-category-header {
@@ -230,10 +234,26 @@
   gap: 1rem;
 }
 
+.cc-category-label-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .cc-category-label {
   font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
+}
+
+.cc-badge {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--cc-text-muted);
+  border: 1px solid var(--cc-border);
+  border-radius: 9999px;
+  padding: 0.125rem 0.5rem;
+  line-height: 1.5;
 }
 
 .cc-category-description {
@@ -360,8 +380,17 @@
   color: var(--cc-primary-hover);
 }
 
+.cc-modal-policy-bar {
+  background-color: var(--cc-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0 0 var(--cc-radius) var(--cc-radius);
+}
+
 .cc-modal-policy-link {
-  margin-top: 0.75rem;
+  margin: 0;
   color: var(--cc-text-muted);
 }
 

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -7,10 +7,11 @@
   --cc-primary-hover: #1d4ed8;
   --cc-bg: #ffffff;
   --cc-surface: #f8fafc;
+  --cc-tint-rgb: 0, 0, 0;
   --cc-text: #0f172a;
   --cc-text-muted: #64748b;
   --cc-border: #e2e8f0;
-  --cc-radius: 1rem;
+  --cc-radius: 1.5rem;
   --cc-radius-pill: 9999px;
   --cc-font-family: inherit;
 }
@@ -27,6 +28,7 @@
     --cc-primary-hover: #60a5fa;
     --cc-bg: #1e293b;
     --cc-surface: #334155;
+    --cc-tint-rgb: 255, 255, 255;
     --cc-text: #f1f5f9;
     --cc-text-muted: #94a3b8;
     --cc-border: #475569;
@@ -45,6 +47,7 @@
   --cc-primary-hover: #1d4ed8;
   --cc-bg: #ffffff;
   --cc-surface: #f8fafc;
+  --cc-tint-rgb: 0, 0, 0;
   --cc-text: #0f172a;
   --cc-text-muted: #64748b;
   --cc-border: #e2e8f0;
@@ -55,6 +58,7 @@
   --cc-primary-hover: #60a5fa;
   --cc-bg: #1e293b;
   --cc-surface: #334155;
+  --cc-tint-rgb: 255, 255, 255;
   --cc-text: #f1f5f9;
   --cc-text-muted: #94a3b8;
   --cc-border: #475569;
@@ -192,12 +196,12 @@
 }
 
 .cc-modal-close:hover {
-  background-color: var(--cc-surface);
+  background-color: rgba(var(--cc-tint-rgb), 0.06);
   color: var(--cc-text);
 }
 
 .cc-modal-body {
-  padding: 1rem 1.5rem;
+  padding: 1rem 1.5rem 1.5rem;
   overflow-y: auto;
   flex: 1 1 auto;
 }
@@ -205,8 +209,8 @@
 .cc-modal-footer {
   display: flex;
   gap: 0.5rem;
-  padding: 1rem 1.5rem;
-  border-top: 1px solid var(--cc-border);
+  padding: 1.5rem;
+  border-top: 1px solid rgba(var(--cc-tint-rgb), 0.08);
   flex-wrap: wrap;
 }
 
@@ -218,7 +222,7 @@
 
 .cc-category {
   padding: 0.875rem 1rem;
-  background-color: var(--cc-surface);
+  background-color: rgba(var(--cc-tint-rgb), 0.02);
   border-radius: 0.75rem;
 }
 
@@ -380,7 +384,7 @@
 }
 
 .cc-modal-policy-bar {
-  background-color: var(--cc-surface);
+  background-color: rgba(var(--cc-tint-rgb), 0.06);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -358,17 +358,6 @@
   background-color: var(--cc-border);
 }
 
-.cc-btn-link {
-  background: none;
-  color: var(--cc-text-muted);
-  padding: 0.5rem 0.75rem;
-  border: none;
-}
-
-.cc-btn-link:hover {
-  color: var(--cc-text);
-}
-
 /* ── Policy link ────────────────────────────────────────── */
 
 .cc-policy-link {

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -11,7 +11,7 @@
   --cc-text-muted: #64748b;
   --cc-border: #e2e8f0;
   --cc-radius: 1rem;
-  --cc-radius-btn: 9999px;
+  --cc-radius-pill: 9999px;
   --cc-font-family: inherit;
 }
 
@@ -166,7 +166,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.5rem 2.5rem 1rem;
+  padding: 1.5rem 1.5rem 1rem 2.5rem;
 }
 
 .cc-modal-title {
@@ -179,16 +179,15 @@
 .cc-modal-close {
   background: none;
   border: none;
-  width: 32px;
-  height: 32px;
-  border-radius: 9999px;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   color: var(--cc-text-muted);
   padding: 0;
-  margin-right: -10px;
   transition: background-color 0.15s ease;
 }
 
@@ -251,7 +250,7 @@
   font-weight: 500;
   color: var(--cc-text-muted);
   border: 1px solid var(--cc-border);
-  border-radius: 9999px;
+  border-radius: var(--cc-radius-pill);
   padding: 0.125rem 0.5rem;
   line-height: 1.5;
 }
@@ -284,7 +283,7 @@
   position: absolute;
   inset: 0;
   background-color: var(--cc-border);
-  border-radius: 9999px;
+  border-radius: var(--cc-radius-pill);
   cursor: pointer;
   transition: background-color 0.2s ease;
 }
@@ -297,7 +296,7 @@
   left: 0.1875rem;
   bottom: 0.1875rem;
   background-color: white;
-  border-radius: 9999px;
+  border-radius: 50%;
   transition: transform 0.2s ease;
   box-sizing: border-box;
 }
@@ -326,7 +325,7 @@
   font-weight: 500;
   font-family: var(--cc-font-family);
   line-height: 1.5;
-  border-radius: var(--cc-radius-btn);
+  border-radius: var(--cc-radius-pill);
   border: 1px solid transparent;
   cursor: pointer;
   transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
@@ -381,7 +380,7 @@
 }
 
 .cc-modal-policy-bar {
-  background-color: var(--cc-border);
+  background-color: var(--cc-surface);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -10,7 +10,8 @@
   --cc-text: #0f172a;
   --cc-text-muted: #64748b;
   --cc-border: #e2e8f0;
-  --cc-radius: 0.5rem;
+  --cc-radius: 1rem;
+  --cc-radius-btn: 9999px;
   --cc-font-family: inherit;
 }
 
@@ -117,7 +118,7 @@
   position: fixed;
   inset: 0;
   z-index: 10000;
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: rgba(0, 0, 0, 0.8);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s ease;
@@ -151,7 +152,6 @@
 
 .cc-modal-inner {
   background-color: var(--cc-bg);
-  border: 1px solid var(--cc-border);
   border-radius: var(--cc-radius);
   width: 100%;
   max-width: 32rem;
@@ -180,14 +180,21 @@
 .cc-modal-close {
   background: none;
   border: none;
-  font-size: 1.5rem;
-  line-height: 1;
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   color: var(--cc-text-muted);
-  padding: 0.25rem;
+  padding: 0;
+  margin-right: -10px;
+  transition: background-color 0.15s ease;
 }
 
 .cc-modal-close:hover {
+  background-color: var(--cc-surface);
   color: var(--cc-text);
 }
 
@@ -299,7 +306,7 @@
   font-weight: 500;
   font-family: var(--cc-font-family);
   line-height: 1.5;
-  border-radius: var(--cc-radius);
+  border-radius: var(--cc-radius-btn);
   border: 1px solid transparent;
   cursor: pointer;
   transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -55,6 +55,7 @@ export interface ConsentText {
   // Essential category
   essentialLabel?: string;
   essentialDescription?: string;
+  essentialBadge?: string;
 
   /** Per-category label/description overrides, keyed by category key. */
   categories?: Record<string, ConsentCategoryText>;

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -25,6 +25,7 @@ const BUILT_IN_DEFAULTS: ResolvedConsentText = {
   savePreferences: 'Save preferences',
   essentialLabel: 'Essential',
   essentialDescription: 'Required for the website to function. Cannot be disabled.',
+  essentialBadge: 'Required',
   categories: {},
 };
 
@@ -50,6 +51,7 @@ function mergeText(base: ResolvedConsentText, layer: ConsentText | undefined): R
   if (layer.essentialDescription !== undefined) {
     next.essentialDescription = layer.essentialDescription;
   }
+  if (layer.essentialBadge !== undefined) next.essentialBadge = layer.essentialBadge;
 
   if (layer.categories) {
     for (const [key, override] of Object.entries(layer.categories)) {
@@ -195,16 +197,20 @@ function createCategoryToggle(
   description: string,
   isEssential: boolean,
   defaultValue: boolean,
+  badge?: string,
 ): string {
   const checked = isEssential || defaultValue ? 'checked' : '';
   const disabled = isEssential ? 'disabled' : '';
   const id = `cc-toggle-${escapeHtml(key)}`;
   const descId = `${id}-desc`;
+  const badgeHtml = badge ? `<span class="cc-badge">${escapeHtml(badge)}</span>` : '';
 
   return `
     <div class="cc-category">
       <div class="cc-category-header">
-        <label class="cc-category-label" for="${id}">${escapeHtml(label)}</label>
+        <div class="cc-category-label-group">
+          <label class="cc-category-label" for="${id}">${escapeHtml(label)}</label>${badgeHtml}
+        </div>
         <label class="cc-toggle">
           <input type="checkbox" id="${id}" data-cc-category="${escapeHtml(key)}" aria-describedby="${descId}" ${checked} ${disabled} />
           <span class="cc-toggle-slider" aria-hidden="true"></span>
@@ -221,6 +227,7 @@ function createModalHTML(config: SerializableConsentConfig, text: ResolvedConsen
     text.essentialDescription,
     true,
     true,
+    text.essentialBadge,
   );
 
   const categoryToggles = Object.entries(config.categories)
@@ -251,12 +258,14 @@ function createModalHTML(config: SerializableConsentConfig, text: ResolvedConsen
         <div class="cc-modal-body">
           ${essentialToggle}
           ${categoryToggles}
-          ${policyLink}
         </div>
         <div class="cc-modal-footer">
           <button type="button" class="cc-btn cc-btn-primary" data-cc="modal-accept-all">${escapeHtml(text.acceptAll)}</button>
           <button type="button" class="cc-btn cc-btn-secondary" data-cc="modal-reject-all">${escapeHtml(text.rejectAll)}</button>
           <button type="button" class="cc-btn cc-btn-primary" data-cc="save-preferences">${escapeHtml(text.savePreferences)}</button>
+        </div>
+        <div class="cc-modal-policy-bar">
+          ${policyLink}
         </div>
       </div>
     </div>`;

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -51,7 +51,9 @@ function mergeText(base: ResolvedConsentText, layer: ConsentText | undefined): R
   if (layer.essentialDescription !== undefined) {
     next.essentialDescription = layer.essentialDescription;
   }
-  if (layer.essentialBadge !== undefined) next.essentialBadge = layer.essentialBadge;
+  if (layer.essentialBadge !== undefined) {
+    next.essentialBadge = layer.essentialBadge;
+  }
 
   if (layer.categories) {
     for (const [key, override] of Object.entries(layer.categories)) {
@@ -264,9 +266,7 @@ function createModalHTML(config: SerializableConsentConfig, text: ResolvedConsen
           <button type="button" class="cc-btn cc-btn-secondary" data-cc="modal-reject-all">${escapeHtml(text.rejectAll)}</button>
           <button type="button" class="cc-btn cc-btn-primary" data-cc="save-preferences">${escapeHtml(text.savePreferences)}</button>
         </div>
-        <div class="cc-modal-policy-bar">
-          ${policyLink}
-        </div>
+        ${policyLink ? `<div class="cc-modal-policy-bar">${policyLink}</div>` : ''}
       </div>
     </div>`;
 }

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -186,8 +186,8 @@ function createBannerHTML(config: SerializableConsentConfig, text: ResolvedConse
         </p>
         <div class="cc-banner-actions">
           <button type="button" class="cc-btn cc-btn-primary" data-cc="accept-all">${escapeHtml(text.acceptAll)}</button>
-          <button type="button" class="cc-btn cc-btn-secondary" data-cc="reject-all">${escapeHtml(text.rejectAll)}</button>
-          <button type="button" class="cc-btn cc-btn-link" data-cc="manage">${escapeHtml(text.manage)}</button>
+          <button type="button" class="cc-btn cc-btn-primary" data-cc="reject-all">${escapeHtml(text.rejectAll)}</button>
+          <button type="button" class="cc-btn cc-btn-secondary" data-cc="manage">${escapeHtml(text.manage)}</button>
         </div>
       </div>
     </div>`;
@@ -263,8 +263,8 @@ function createModalHTML(config: SerializableConsentConfig, text: ResolvedConsen
         </div>
         <div class="cc-modal-footer">
           <button type="button" class="cc-btn cc-btn-primary" data-cc="modal-accept-all">${escapeHtml(text.acceptAll)}</button>
-          <button type="button" class="cc-btn cc-btn-secondary" data-cc="modal-reject-all">${escapeHtml(text.rejectAll)}</button>
-          <button type="button" class="cc-btn cc-btn-primary" data-cc="save-preferences">${escapeHtml(text.savePreferences)}</button>
+          <button type="button" class="cc-btn cc-btn-primary" data-cc="modal-reject-all">${escapeHtml(text.rejectAll)}</button>
+          <button type="button" class="cc-btn cc-btn-secondary" data-cc="save-preferences">${escapeHtml(text.savePreferences)}</button>
         </div>
         ${policyLink ? `<div class="cc-modal-policy-bar">${policyLink}</div>` : ''}
       </div>

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -246,7 +246,7 @@ function createModalHTML(config: SerializableConsentConfig, text: ResolvedConsen
       <div class="cc-modal-inner">
         <div class="cc-modal-header">
           <h2 class="cc-modal-title" id="${MODAL_TITLE_ID}">${escapeHtml(text.modalTitle)}</h2>
-          <button type="button" class="cc-modal-close" data-cc="close-modal" aria-label="${escapeHtml(text.closeAriaLabel)}">&times;</button>
+          <button type="button" class="cc-modal-close" data-cc="close-modal" aria-label="${escapeHtml(text.closeAriaLabel)}"><svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="10" y2="10"/><line x1="10" y1="2" x2="2" y2="10"/></svg></button>
         </div>
         <div class="cc-modal-body">
           ${essentialToggle}

--- a/playground/e2e/runtime-api.spec.ts
+++ b/playground/e2e/runtime-api.spec.ts
@@ -13,9 +13,9 @@ test.describe('Runtime API', () => {
     expect(state).toBeNull();
   });
 
-  test('set() creates initial consent from defaults', async ({ page }) => {
+  test('set() creates initial consent from explicit values', async ({ page }) => {
     await page.evaluate(() => {
-      window.astroConsent?.set({ analytics: true });
+      window.astroConsent?.set({ analytics: true, marketing: false });
     });
 
     const state = await getConsentAPI(page);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? 'github' : 'html',
 
   webServer: {

--- a/scripts/dev-parallel.mjs
+++ b/scripts/dev-parallel.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Tiny zero-dep parallel process runner. Each argv is "label=command"; the
+// command is handed to a shell so quoting works naturally. On SIGINT/SIGTERM
+// or any child exiting non-zero, the rest are killed and the exit code is
+// propagated.
+import { spawn } from 'node:child_process';
+
+const specs = process.argv.slice(2).map((arg) => {
+  const i = arg.indexOf('=');
+  if (i === -1) {
+    console.error(`dev-parallel: expected "label=command", got: ${arg}`);
+    process.exit(2);
+  }
+  return { label: arg.slice(0, i), command: arg.slice(i + 1) };
+});
+
+if (specs.length === 0) {
+  console.error('usage: dev-parallel.mjs "label=command" ...');
+  process.exit(2);
+}
+
+const COLORS = ['\x1b[36m', '\x1b[35m', '\x1b[32m', '\x1b[33m', '\x1b[34m'];
+const RESET = '\x1b[0m';
+const pad = Math.max(...specs.map((s) => s.label.length));
+const prefix = (label, color) => `${color}[${label.padEnd(pad)}]${RESET} `;
+
+function pipe(stream, label, color) {
+  let buf = '';
+  stream.on('data', (chunk) => {
+    buf += chunk.toString();
+    let i;
+    while ((i = buf.indexOf('\n')) !== -1) {
+      process.stdout.write(prefix(label, color) + buf.slice(0, i + 1));
+      buf = buf.slice(i + 1);
+    }
+  });
+  stream.on('end', () => {
+    if (buf) process.stdout.write(prefix(label, color) + buf + '\n');
+  });
+}
+
+const children = specs.map((spec, i) => {
+  const color = COLORS[i % COLORS.length];
+  const child = spawn(spec.command, { shell: true, stdio: ['ignore', 'pipe', 'pipe'] });
+  pipe(child.stdout, spec.label, color);
+  pipe(child.stderr, spec.label, color);
+  return { spec, child, color };
+});
+
+let shuttingDown = false;
+let exitCode = 0;
+
+function shutdown(code) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  if (code != null) exitCode = code;
+  for (const { child } of children) {
+    if (child.exitCode == null && child.signalCode == null) {
+      try { child.kill('SIGTERM'); } catch { /* ignore */ }
+    }
+  }
+  setTimeout(() => {
+    for (const { child } of children) {
+      if (child.exitCode == null && child.signalCode == null) {
+        try { child.kill('SIGKILL'); } catch { /* ignore */ }
+      }
+    }
+  }, 5000).unref();
+}
+
+for (const { spec, child, color } of children) {
+  child.on('exit', (code, signal) => {
+    const reason = signal ? `signal ${signal}` : `code ${code}`;
+    process.stdout.write(prefix(spec.label, color) + `exited (${reason})\n`);
+    if (!shuttingDown) shutdown(code ?? 1);
+  });
+}
+
+process.on('SIGINT', () => shutdown(0));
+process.on('SIGTERM', () => shutdown(0));
+
+await Promise.all(
+  children.map(({ child }) => new Promise((r) => child.once('close', r))),
+);
+process.exit(exitCode);


### PR DESCRIPTION
## Summary
- Refined modal UI (borderless, rounded corners, improved close button), category cards with Required badge, policy bar, and footer layout
- Tint-based surfaces, symmetric modal spacing, larger corner radii
- Accept all / Reject all are both primary; Manage / Save preferences are secondary
- Mobile (≤480px): Accept and Reject share the top row; Manage / Save span full-width below
- Removed unused \`.cc-btn-link\` class (flagged in changeset as minor)
- Dev ergonomics: package watchers run in parallel with playground dev via \`scripts/dev-parallel.mjs\`

## Test plan
- [x] Verify banner and modal at 430×775 (iPhone) — two primary buttons on top row, third full-width below, no label wrapping
- [x] Verify desktop layout (≥ 481px) unchanged
- [x] Light and dark themes both render correctly
- [ ] Playwright e2e passes
- [ ] No consumers rely on \`.cc-btn-link\` (documented in changeset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)