### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/.changeset/consent-script-component.md
+++ b/.changeset/consent-script-component.md
@@ -1,0 +1,33 @@
+---
+'@zdenekkurecka/astro-consent': minor
+---
+
+Added `<ConsentScript>` Astro component for category-gated scripts.
+
+Ship at `@zdenekkurecka/astro-consent/components`, wraps the existing
+`type="text/plain"` + `data-cc-category` markup with a named-prop API that
+the declarative blocking runtime already knows how to activate.
+
+```astro
+---
+import { ConsentScript } from '@zdenekkurecka/astro-consent/components';
+---
+
+<!-- External — renders as type="text/plain" with data-cc-src -->
+<ConsentScript
+  category="analytics"
+  src="https://www.googletagmanager.com/gtag/js?id=G-XXX"
+  async
+/>
+
+<!-- Inline — slot content becomes the script body -->
+<ConsentScript category="analytics">
+  {`gtag('js', new Date()); gtag('config', 'G-XXX');`}
+</ConsentScript>
+```
+
+Any other `<script>` attributes (`defer`, `nonce`, `integrity`, `crossorigin`,
+…) pass through to the placeholder and survive activation. `is:inline` is
+applied automatically so Astro leaves the placeholder markup intact.
+
+Closes #21.

--- a/.changeset/declarative-script-blocking.md
+++ b/.changeset/declarative-script-blocking.md
@@ -1,0 +1,37 @@
+---
+'@zdenekkurecka/astro-consent': minor
+---
+
+Declarative script blocking via `data-cc-category` / `data-cc-src`.
+
+Third-party scripts and embeds can now be gated with markup instead of
+bespoke event listeners. Mark a placeholder with `type="text/plain"` and a
+category — the integration activates it once consent is granted.
+
+```astro
+<script
+  is:inline
+  type="text/plain"
+  data-cc-category="analytics"
+  data-cc-src="https://www.googletagmanager.com/gtag/js?id=G-XXX"
+  async
+></script>
+
+<iframe data-cc-category="marketing" data-cc-src="…"></iframe>
+```
+
+Supports external scripts (`data-cc-src`), inline bodies, and iframe embeds.
+Covers both the initial scan on `astro-consent:consent` / `:change` and a
+`MutationObserver` for elements inserted after the first scan. All other
+attributes (`async`, `defer`, `nonce`, `integrity`, `crossorigin`, …) flow
+through to the activated script. Activated elements are marked with
+`data-cc-activated="true"`.
+
+The event-based hook (`document.addEventListener('astro-consent:consent', …)`)
+is still the right choice when you need custom bootstrap or teardown logic;
+the two approaches compose.
+
+Note: activation is one-way within a page lifecycle — once a tracker runs,
+the integration cannot unload it. Revoking a category stops future loads
+(e.g. after a full reload or on pages that haven't scanned yet) but does
+not tear down already-executed code.

--- a/.changeset/fix-event-type-and-nonce.md
+++ b/.changeset/fix-event-type-and-nonce.md
@@ -1,0 +1,20 @@
+---
+'@zdenekkurecka/astro-consent': patch
+---
+
+Fix two regressions surfaced during the v0.3.0 code review:
+
+- **Event type on re-accept/re-reject.** When a user re-opened the banner
+  or preferences modal after already consenting (e.g. via
+  `window.astroConsent.show()` / `showPreferences()`) and clicked
+  "Accept all" / "Reject all", the integration dispatched
+  `astro-consent:consent` again instead of `astro-consent:change`. The
+  `save-preferences` path already discriminated correctly; the two
+  accept/reject branches now follow the same rule.
+
+- **CSP nonce lost on script activation.** Declarative blocking cloned
+  placeholder `<script>` elements via `getAttribute`/`setAttribute`, but
+  CSP L3 hides the `nonce` content attribute post-parse so the copy
+  landed as an empty string and the activated script was blocked by a
+  nonce'd CSP. The runtime now copies the nonce via the `.nonce` IDL
+  property so the injected script matches the page policy.

--- a/.changeset/generic-category-keys.md
+++ b/.changeset/generic-category-keys.md
@@ -1,0 +1,28 @@
+---
+'@zdenekkurecka/astro-consent': minor
+---
+
+Type-safe category keys via generic config.
+
+`ConsentConfig`, `ConsentState`, and `ConsentText` now take an optional
+`K extends string` generic that narrows `categories` (and `text.categories`)
+to the literal keys you defined. When you pass a config to `cookieConsent`,
+TypeScript infers `K` from the `categories` map — so typos in downstream
+lookups are caught and autocompletion suggests the right keys.
+
+```ts
+const config = {
+  version: 1,
+  categories: {
+    analytics: { label: 'Analytics', description: '…', default: false },
+    marketing: { label: 'Marketing', description: '…', default: false },
+  },
+} satisfies ConsentConfig<'analytics' | 'marketing'>;
+
+// state.categories.analyitcs → type error, with a "did you mean 'analytics'?" hint
+```
+
+The generic defaults to `string`, so existing code keeps compiling unchanged.
+End-to-end typing of the `astro-consent:consent` / `:change` event payload
+still requires a user-land `declare module` augmentation (the Vite virtual
+module boundary erases the generic); that is tracked as a follow-up.

--- a/.changeset/generic-category-keys.md
+++ b/.changeset/generic-category-keys.md
@@ -24,5 +24,5 @@ const config = {
 
 The generic defaults to `string`, so existing code keeps compiling unchanged.
 End-to-end typing of the `astro-consent:consent` / `:change` event payload
-still requires a user-land `declare module` augmentation (the Vite virtual
-module boundary erases the generic); that is tracked as a follow-up.
+and `window.astroConsent` is available via the `ConsentKeys` augmentation
+pattern — see the Events / "Typed category keys" section in the README.

--- a/.changeset/google-consent-mode-v2.md
+++ b/.changeset/google-consent-mode-v2.md
@@ -1,0 +1,39 @@
+---
+'@zdenekkurecka/astro-consent': minor
+---
+
+First-class Google Consent Mode v2 support via a new `googleConsentMode`
+config option.
+
+When configured, the integration:
+
+1. Injects an inline snippet at the top of `<head>` that bootstraps
+   `window.dataLayer` + `gtag` and calls `gtag('consent', 'default', …)` with
+   every mapped signal denied (plus `wait_for_update`).
+2. Bridges `astro-consent:consent` / `astro-consent:change` into
+   `gtag('consent', 'update', …)` automatically — a signal is granted only
+   when every category that maps to it is granted (AND semantics).
+3. Forwards `adsDataRedaction` / `urlPassthrough` via `gtag('set', …)`.
+4. Emits one additional default per `regions` entry so CCPA-style opt-out
+   markets (e.g. `regions: { US: 'granted' }`) start granted.
+
+```ts
+cookieConsent({
+  version: 1,
+  categories: { /* … */ },
+  googleConsentMode: {
+    mapping: {
+      analytics: ['analytics_storage'],
+      marketing: ['ad_storage', 'ad_user_data', 'ad_personalization'],
+    },
+    waitForUpdate: 500,
+    regions: { US: 'granted' },
+    adsDataRedaction: true,
+  },
+});
+```
+
+The feature is opt-in; omitting `googleConsentMode` keeps the integration
+strict-CSP-safe. Enabling it requires `script-src` to include
+`'unsafe-inline'` (or a matching hash) because the default snippet must run
+synchronously before any GTM/gtag.js loads.

--- a/.changeset/typed-events-and-runtime-api.md
+++ b/.changeset/typed-events-and-runtime-api.md
@@ -1,0 +1,31 @@
+---
+'@zdenekkurecka/astro-consent': minor
+---
+
+Typed event listeners and runtime API via `ConsentKeys` augmentation.
+
+Drop a project-level `.d.ts` to make every `astro-consent:consent` /
+`:change` listener and `window.astroConsent` narrow to your declared
+category keys:
+
+```ts
+// src/astro-consent.d.ts
+declare module '@zdenekkurecka/astro-consent' {
+  interface ConsentKeys {
+    analytics: true;
+    marketing: true;
+  }
+}
+export {};
+```
+
+With the augmentation in place, `e.detail.categories.analyitcs` and
+`window.astroConsent?.set({ analyitcs: true })` become compile-time errors,
+and autocompletion suggests the declared keys. Without it, both fall back
+to `Record<string, boolean>` — same behaviour as before.
+
+Also re-exports `ConsentEvent`, `ConsentKeys`, `ResolvedConsentKeys`,
+`CONSENT_EVENT`, and `CHANGE_EVENT` from the package entry so consumers
+don't need to import from internal paths.
+
+Closes #70, #71.

--- a/README.md
+++ b/README.md
@@ -394,6 +394,29 @@ Use `is:inline` so Astro leaves the placeholder markup untouched — otherwise
 the compiler may bundle or rewrite the tag and break the `type="text/plain"`
 convention.
 
+**`<ConsentScript>` component.** A thin Astro component is exported from
+`@zdenekkurecka/astro-consent/components` for the common case — it emits the
+same placeholder markup as above (including `is:inline`) with a named-prop
+API and forwards any other `<script>` attributes through:
+
+```astro
+---
+import { ConsentScript } from '@zdenekkurecka/astro-consent/components';
+---
+<ConsentScript
+  category="analytics"
+  src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"
+  async
+/>
+
+<ConsentScript category="analytics">
+  {`window.dataLayer = window.dataLayer || [];
+  function gtag(){ dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXX');`}
+</ConsentScript>
+```
+
 How it works:
 
 - On `astro-consent:consent` / `astro-consent:change`, the integration scans

--- a/README.md
+++ b/README.md
@@ -97,10 +97,12 @@ npx astro add @zdenekkurecka/astro-consent
 yarn astro add @zdenekkurecka/astro-consent
 ```
 
-> **Heads up:** `cookieConsent()` requires at least `version` and `categories`.
-> `astro add` inserts a bare `cookieConsent()` call — open `astro.config.*`
-> after it runs and pass the required options shown in [Quick start](#quick-start).
-> You'll get a clear error at build time if you forget.
+> **Heads up:** the integration requires at least `version` and `categories`.
+> `astro add` inserts a bare integration call with an auto-derived import name
+> (`zdenekkureckaconsent()`) — open `astro.config.*` after it runs and pass the
+> required options shown in [Quick start](#quick-start). Feel free to rename
+> the import to `cookieConsent` to match the examples below. You'll get a
+> clear error at build time if you forget to fill in the config.
 
 Or install manually:
 
@@ -863,7 +865,7 @@ if you don't declare it, and the narrow type kicks in the moment you do.
 
 This repository is a pnpm workspace:
 
-```
+```text
 .
 ├── packages/
 │   └── astro-consent/        # the published npm package

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ they force you to serialize your tracker callbacks into a JSON config.
   translated or customised
 - **Accessible modal**: `role="dialog"` / `aria-modal`, focus trap, focus
   restoration, `Escape` to close, click-outside to dismiss
+- **Declarative script blocking** via `type="text/plain"` +
+  `data-cc-category` — gate trackers and embeds without writing glue code
 - **Strict-CSP safe**: no inline `<script>`, no inline `<style>`
 - **View Transitions ready**: initializes on `DOMContentLoaded` *and*
   `astro:page-load`, idempotently
@@ -338,9 +340,69 @@ window.astroConsent?.showPreferences();
 
 ### Gate third-party scripts (GA, Meta Pixel, …)
 
-The pattern is always the same: listen for `astro-consent:consent`, and only
-load the tracker if the relevant category is enabled. Then listen for
-`astro-consent:change` to react when the user later updates their choices.
+There are two ways to gate a tracker: a declarative markup pattern (good for
+90% of cases), and the event-based hook (for anything that needs custom
+logic). They compose — use whichever fits each tracker.
+
+#### Declarative blocking (recommended)
+
+Mark a `<script>` with `type="text/plain"` and a `data-cc-category`. The
+browser treats `text/plain` scripts as inert data, so the tracker stays
+dormant until the integration unblocks it once the category is granted.
+Use `data-cc-src` for external scripts and a plain body for inline ones.
+
+```astro
+<!-- External — recommended, CSP-safe -->
+<script
+  is:inline
+  type="text/plain"
+  data-cc-category="analytics"
+  data-cc-src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"
+  async
+></script>
+
+<!-- Inline — requires `'unsafe-inline'` (or a nonce) under strict CSP -->
+<script is:inline type="text/plain" data-cc-category="analytics">
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){ dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXX');
+</script>
+
+<!-- iframe embeds work the same way -->
+<iframe
+  data-cc-category="marketing"
+  data-cc-src="https://www.youtube.com/embed/…"
+></iframe>
+```
+
+Use `is:inline` so Astro leaves the placeholder markup untouched — otherwise
+the compiler may bundle or rewrite the tag and break the `type="text/plain"`
+convention.
+
+How it works:
+
+- On `astro-consent:consent` / `astro-consent:change`, the integration scans
+  for blocked elements whose category is now granted and activates them in
+  place.
+- A `MutationObserver` catches blocked elements inserted after the initial
+  scan (e.g. via client-side routing or framework islands).
+- All other attributes on the placeholder (`async`, `defer`, `nonce`,
+  `integrity`, `crossorigin`, …) are preserved on the activated script.
+- Activated elements are marked with `data-cc-activated="true"` so repeated
+  scans are a no-op.
+
+**Revocation caveat.** Once a tracker has executed, the integration cannot
+unload it — most trackers aren't teardown-safe. If a user later revokes a
+category, the next full page load will keep those scripts blocked, but the
+current session will still have them running. Design accordingly, or drive
+teardown yourself from `astro-consent:change`.
+
+#### Event-based hook (advanced / full control)
+
+For trackers that need custom bootstrap logic — dynamic config, manual
+teardown, integration with `window.dataLayer` before the script tag lands —
+listen to the consent events directly:
 
 ```astro
 <script>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   - [Open the preferences modal from a footer link](#open-the-preferences-modal-from-a-footer-link)
   - [Gate third-party scripts (GA, Meta Pixel, …)](#gate-third-party-scripts-ga-meta-pixel-)
   - [Enable Google Consent Mode v2](#enable-google-consent-mode-v2)
+  - [Recipes (GA4, GTM, Meta Pixel)](#recipes-ga4-gtm-meta-pixel)
   - [Re-prompt users after changing categories](#re-prompt-users-after-changing-categories)
   - [Customise banner & modal text (and localize it)](#customise-banner--modal-text-and-localize-it)
   - [Theme the UI](#theme-the-ui)
@@ -557,6 +558,16 @@ type GoogleConsentSignal =
   | 'personalization_storage'
   | 'security_storage';
 ```
+
+### Recipes (GA4, GTM, Meta Pixel)
+
+Copy-paste wiring for the trackers people ask about most often, with
+category mappings, GCM configuration where relevant, and tracker-specific
+gotchas. These live under [`docs/recipes/`](https://github.com/zdenekkurecka/astro-consent/blob/main/docs/recipes/):
+
+- [Google Analytics 4 (gtag.js)](https://github.com/zdenekkurecka/astro-consent/blob/main/docs/recipes/ga4.md)
+- [Google Tag Manager](https://github.com/zdenekkurecka/astro-consent/blob/main/docs/recipes/gtm.md)
+- [Meta Pixel (Facebook)](https://github.com/zdenekkurecka/astro-consent/blob/main/docs/recipes/meta-pixel.md)
 
 ### Re-prompt users after changing categories
 

--- a/README.md
+++ b/README.md
@@ -808,6 +808,43 @@ window.astroConsent?.reset();
 Both are typed `CustomEvent`s on `document`, so in TypeScript you get full
 autocompletion on `e.detail.categories`.
 
+### Typed category keys
+
+By default `e.detail.categories` is typed as `Record<string, boolean>` — usable,
+but no autocomplete and typos don't error. To get the category keys you
+declared in `cookieConsent({ categories: … })` to narrow across every listener
+*and* `window.astroConsent`, drop a project-level `.d.ts` that augments the
+`ConsentKeys` marker interface:
+
+```ts
+// src/astro-consent.d.ts
+declare module '@zdenekkurecka/astro-consent' {
+  interface ConsentKeys {
+    analytics: true;
+    marketing: true;
+  }
+}
+
+export {};
+```
+
+After this, both event listeners and the runtime API narrow:
+
+```ts
+document.addEventListener('astro-consent:consent', (e) => {
+  e.detail.categories.analytics; // boolean
+  e.detail.categories.analyitcs; // ❌ TS error — unknown key
+});
+
+window.astroConsent?.get()?.categories.marketing; // boolean
+window.astroConsent?.set({ analytics: true });    // ✓
+window.astroConsent?.set({ analyitcs: true });    // ❌ TS error
+```
+
+This is an opt-in pattern (same shape as Vue Router's `RouteMap` or Pinia's
+store augmentation): the library ships with a wide default so nothing breaks
+if you don't declare it, and the narrow type kicks in the moment you do.
+
 ## Accessibility
 
 - Modal has `role="dialog"` with `aria-modal="true"` and `aria-labelledby`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   - [Trigger the UI from your own buttons](#trigger-the-ui-from-your-own-buttons)
   - [Open the preferences modal from a footer link](#open-the-preferences-modal-from-a-footer-link)
   - [Gate third-party scripts (GA, Meta Pixel, …)](#gate-third-party-scripts-ga-meta-pixel-)
+  - [Enable Google Consent Mode v2](#enable-google-consent-mode-v2)
   - [Re-prompt users after changing categories](#re-prompt-users-after-changing-categories)
   - [Customise banner & modal text (and localize it)](#customise-banner--modal-text-and-localize-it)
   - [Theme the UI](#theme-the-ui)
@@ -73,6 +74,9 @@ they force you to serialize your tracker callbacks into a JSON config.
   restoration, `Escape` to close, click-outside to dismiss
 - **Declarative script blocking** via `type="text/plain"` +
   `data-cc-category` — gate trackers and embeds without writing glue code
+- **Google Consent Mode v2** out of the box: opt-in config that maps your
+  categories to GCM signals, injects the default-denied snippet, and wires
+  `gtag('consent', 'update', …)` into the consent events
 - **Strict-CSP safe**: no inline `<script>`, no inline `<style>`
 - **View Transitions ready**: initializes on `DOMContentLoaded` *and*
   `astro:page-load`, idempotently
@@ -220,6 +224,16 @@ interface ConsentConfig {
    * built-in defaults.
    */
   localeText?: Record<string, ConsentText>;
+
+  /**
+   * Google Consent Mode v2 integration. When set, the integration injects an
+   * inline snippet at the top of `<head>` to pre-declare denied defaults, and
+   * auto-dispatches `gtag('consent', 'update', …)` on every consent event.
+   *
+   * Opt-in. Requires `'unsafe-inline'` (or a matching hash) under strict CSP —
+   * see [Enable Google Consent Mode v2](#enable-google-consent-mode-v2).
+   */
+  googleConsentMode?: GoogleConsentModeConfig;
 }
 
 interface ConsentText {
@@ -427,6 +441,98 @@ listen to the consent events directly:
     if (e.detail.categories.analytics) loadGA();
   });
 </script>
+```
+
+### Enable Google Consent Mode v2
+
+GA4, Google Ads, and every other Google tag need
+[Consent Mode v2](https://developers.google.com/tag-platform/security/concepts/consent-mode)
+to run legally in the EU. The integration ships first-class support: map your
+categories to GCM signals and the rest is handled for you.
+
+```ts
+cookieConsent({
+  version: 1,
+  categories: {
+    analytics: { label: 'Analytics', description: '…', default: false },
+    marketing: { label: 'Marketing', description: '…', default: false },
+  },
+  googleConsentMode: {
+    enabled: true,
+    mapping: {
+      analytics: ['analytics_storage'],
+      marketing: ['ad_storage', 'ad_user_data', 'ad_personalization'],
+    },
+    // Hint to GTM on how long to delay firing tags. Default 500ms.
+    waitForUpdate: 500,
+    // Optional: regional default overrides. Accepts either a single value
+    // (applied to every mapped signal) or a per-signal object.
+    regions: {
+      US: 'granted',
+      BR: { ad_storage: 'denied' },
+    },
+    // Optional Google flags, forwarded via gtag('set', …).
+    adsDataRedaction: true,
+    urlPassthrough: false,
+  },
+});
+```
+
+What the integration does for you:
+
+1. Injects an inline snippet at the top of `<head>` that bootstraps
+   `window.dataLayer` + `gtag` and calls `gtag('consent', 'default', { …,
+   wait_for_update: 500 })` with every mapped signal set to `"denied"` (unless
+   overridden via `defaults` / `regions`).
+2. On every `astro-consent:consent` or `astro-consent:change` event,
+   dispatches `gtag('consent', 'update', …)` with each signal set to
+   `"granted"` only when **every** category that maps to it is granted.
+3. Forwards `adsDataRedaction` / `urlPassthrough` as `gtag('set', …)` calls in
+   the default snippet.
+
+Drop your GA4 / Google Ads tag anywhere in your layout (or gate it via
+`data-cc-category` — the two compose) and it will pick up the consent state
+automatically:
+
+```astro
+<script
+  is:inline
+  async
+  src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"
+></script>
+<script is:inline>
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXX');
+</script>
+```
+
+**CSP caveat.** The default snippet is inline, so enabling
+`googleConsentMode` requires `script-src` to include `'unsafe-inline'` or a
+matching hash/nonce. If you don't configure `googleConsentMode`, the
+integration stays strict-CSP-safe.
+
+```ts
+interface GoogleConsentModeConfig {
+  enabled?: boolean;                                          // default: true
+  mapping: Partial<Record<string, GoogleConsentSignal[]>>;
+  waitForUpdate?: number;                                     // default: 500
+  defaults?: Partial<Record<GoogleConsentSignal, 'granted' | 'denied'>>;
+  regions?: Record<string,
+    | 'granted' | 'denied'
+    | Partial<Record<GoogleConsentSignal, 'granted' | 'denied'>>
+  >;
+  adsDataRedaction?: boolean;
+  urlPassthrough?: boolean;
+}
+
+type GoogleConsentSignal =
+  | 'ad_storage'
+  | 'ad_user_data'
+  | 'ad_personalization'
+  | 'analytics_storage'
+  | 'functionality_storage'
+  | 'personalization_storage'
+  | 'security_storage';
 ```
 
 ### Re-prompt users after changing categories

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -1,0 +1,39 @@
+# Recipes
+
+Copy-paste wiring for the trackers developers most often ask about. Each recipe
+builds on the primitives documented in the main
+[README](../../README.md) — declarative `<ConsentScript>` / `data-cc-*`
+blocking, the `astro-consent:consent` / `astro-consent:change` events, and the
+`googleConsentMode` integration option. The recipes just pick the right tool
+for each tracker and call out the tracker-specific gotchas.
+
+| Tracker                 | Typical category | Recipe                         |
+| ----------------------- | ---------------- | ------------------------------ |
+| Google Analytics 4      | `analytics`      | [ga4.md](./ga4.md)             |
+| Google Tag Manager      | `analytics` (+ GCM) | [gtm.md](./gtm.md)         |
+| Meta Pixel (Facebook)   | `marketing`      | [meta-pixel.md](./meta-pixel.md) |
+
+> **Category naming.** Category keys are yours to define. The recipes assume
+> `analytics` and `marketing` to match the examples in the main README — if
+> your config uses different keys, substitute them everywhere.
+
+## Which pattern should I use?
+
+- **Declarative `<ConsentScript>`** — default choice. Works for any tracker
+  that just needs its `<script>` tag to execute once consent is granted. Keeps
+  the wiring in the markup, no glue code.
+- **Google Consent Mode v2** (`googleConsentMode` config) — *always* use this
+  for Google tags (GA4, Google Ads, GTM). It sends denied-by-default signals
+  so Google tags can run in a consent-aware degraded mode before opt-in, and
+  lets you drop the gtag / GTM snippet without wrapping it in a consent gate.
+- **Event-based hook** — reach for this when you need custom bootstrap logic,
+  dynamic config, or teardown on revocation. See
+  [the README](../../README.md#event-based-hook-advanced--full-control) for
+  the pattern.
+
+## A note on revocation
+
+Once a tracker's script has executed, the integration can't unload it — most
+trackers are not teardown-safe. The next full page load will keep the script
+blocked once the user revokes, but the current session still has it running.
+The individual recipes call this out where it matters.

--- a/docs/recipes/ga4.md
+++ b/docs/recipes/ga4.md
@@ -1,0 +1,126 @@
+# Google Analytics 4 (gtag.js)
+
+GA4 is the plain `gtag.js` tag — no container in the middle. There are two
+ways to wire it up.
+
+- [**Recommended: with Google Consent Mode v2**](#recommended-with-google-consent-mode-v2)
+  — let GA4 load unconditionally and respect consent via GCM signals.
+- [**Alternative: block until consent**](#alternative-block-the-tag-until-consent)
+  — gate the entire `<script>` behind the `analytics` category.
+
+## Category mapping
+
+| Category    | Purpose                          |
+| ----------- | -------------------------------- |
+| `analytics` | GA4 page views, events, sessions |
+
+## Recommended: with Google Consent Mode v2
+
+Pros: GA4 can collect anonymous pings (e.g. `gtag('config', ..., { 'anonymize_ip': true })`-style
+behaviour built into GCM) before consent, ensuring model-based conversion
+attribution works once the user opts in.
+
+### 1. Configure the integration
+
+```ts
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import cookieConsent from '@zdenekkurecka/astro-consent';
+
+export default defineConfig({
+  integrations: [
+    cookieConsent({
+      version: 1,
+      categories: {
+        analytics: {
+          label: 'Analytics',
+          description: 'Helps us understand how visitors use the site.',
+          default: false,
+        },
+      },
+      googleConsentMode: {
+        enabled: true,
+        mapping: {
+          analytics: ['analytics_storage'],
+        },
+      },
+    }),
+  ],
+});
+```
+
+### 2. Drop the GA4 tag in your layout
+
+```astro
+---
+// src/layouts/Layout.astro
+---
+<html>
+  <head>
+    <script
+      is:inline
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"
+    ></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', 'G-XXXXXXX');
+    </script>
+  </head>
+  <body><slot /></body>
+</html>
+```
+
+The integration's GCM snippet runs *before* these tags at the top of `<head>`
+(see the README). GA4 boots, reads the denied-by-default signals, and only
+starts writing cookies after `astro-consent:consent` triggers the
+`gtag('consent', 'update', ...)` bridge.
+
+### Gotchas
+
+- **Order matters.** The integration's GCM snippet must execute before
+  `gtag.js`. It does, because the integration injects at the top of `<head>`
+  — as long as you don't inject GA4 *before* the integration's output (e.g.
+  via a custom Astro hook earlier in the pipeline), you're fine.
+- **CSP.** The GCM default snippet is inline, so `script-src` must allow
+  `'unsafe-inline'` (or a matching hash). Same goes for the inline
+  `gtag('config', ...)` call above — extract it into an external file if you
+  want strict CSP.
+- **`anonymize_ip` is gone.** GA4 anonymises IPs automatically; don't copy
+  the old Universal Analytics flag from the internet.
+
+## Alternative: block the tag until consent
+
+Use this if you can't enable GCM (strict CSP with no inline allowance, or
+you don't want the denied-by-default pings).
+
+```astro
+---
+import { ConsentScript } from '@zdenekkurecka/astro-consent/components';
+---
+<ConsentScript
+  category="analytics"
+  src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"
+  async
+/>
+<ConsentScript category="analytics">
+  {`window.dataLayer = window.dataLayer || [];
+  function gtag(){ dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXX');`}
+</ConsentScript>
+```
+
+GA4 doesn't load at all until `analytics` is granted. Fine for most sites;
+the trade-off is that you lose GCM's pre-consent modelled data.
+
+### Revocation
+
+If the user revokes analytics in the preferences modal, the current session
+keeps GA4 running — there's no clean gtag teardown API. The next page load
+honours the new state and keeps the tag blocked. If this matters, prefer the
+GCM approach: `gtag('consent', 'update', { analytics_storage: 'denied' })` is
+dispatched automatically by the integration on revocation, and GA4 will stop
+writing cookies from that point forward.

--- a/docs/recipes/gtm.md
+++ b/docs/recipes/gtm.md
@@ -1,0 +1,140 @@
+# Google Tag Manager
+
+GTM is a container: it ships a single loader script that then fires whatever
+tags you configure inside the GTM UI. The correct consent integration is
+almost always **Google Consent Mode v2** — it lets each tag inside the
+container opt into consent-aware behaviour on its own, which is exactly how
+Google expects the pipeline to work.
+
+## Category mapping
+
+Conceptually, GTM itself is consent-neutral — it's a loader. What matters is
+which signals the *tags inside it* read. Map every GCM signal your tags will
+check:
+
+| Category    | GCM signals                                                |
+| ----------- | ---------------------------------------------------------- |
+| `analytics` | `analytics_storage`                                        |
+| `marketing` | `ad_storage`, `ad_user_data`, `ad_personalization`         |
+
+## Recommended: with Google Consent Mode v2
+
+### 1. Configure the integration
+
+```ts
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import cookieConsent from '@zdenekkurecka/astro-consent';
+
+export default defineConfig({
+  integrations: [
+    cookieConsent({
+      version: 1,
+      categories: {
+        analytics: { label: 'Analytics', description: '…', default: false },
+        marketing: { label: 'Marketing', description: '…', default: false },
+      },
+      googleConsentMode: {
+        enabled: true,
+        mapping: {
+          analytics: ['analytics_storage'],
+          marketing: ['ad_storage', 'ad_user_data', 'ad_personalization'],
+        },
+        // Hint GTM to wait this long before firing tags so the update call
+        // can land first. 500ms is Google's recommended default.
+        waitForUpdate: 500,
+      },
+    }),
+  ],
+});
+```
+
+### 2. Drop the GTM snippet in your layout
+
+```astro
+---
+// src/layouts/Layout.astro
+---
+<html>
+  <head>
+    <script is:inline>
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;
+      j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+      f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-XXXXXXX');
+    </script>
+  </head>
+  <body>
+    <!-- GTM noscript fallback. -->
+    <noscript>
+      <iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX"
+        height="0"
+        width="0"
+        style="display:none;visibility:hidden"
+      ></iframe>
+    </noscript>
+    <slot />
+  </body>
+</html>
+```
+
+The integration emits its GCM default snippet at the top of `<head>` *before*
+GTM loads, so `gtag('consent', 'default', …)` runs first. Each tag you
+configure in the GTM UI should have its "Consent Settings" set to "Require
+additional consent" for the relevant signals — GTM will then defer or fire
+them based on the signal state.
+
+### 3. Configure your tags inside GTM
+
+In the GTM UI, for every tag:
+
+1. Open **Tag Configuration → Advanced Settings → Consent Settings**.
+2. Set the **Consent Type** to e.g. `analytics_storage` (for GA4) or
+   `ad_storage` + `ad_user_data` + `ad_personalization` (for Google Ads).
+
+This is the step that most integrations forget. Without it, your tags ignore
+the consent signal and fire regardless.
+
+### Gotchas
+
+- **`dataLayer` must already exist.** The integration's GCM snippet initialises
+  `window.dataLayer` before GTM's loader runs, so you don't need to do it
+  yourself — but if you push events from Astro components, make sure those
+  pushes don't run before the GCM snippet either.
+- **`waitForUpdate`.** The default 500ms gives the banner time to render and
+  the user time to click if they're fast. If your page is very slow to
+  interactive, bump it. If you want no delay on return visits where consent
+  is already stored, don't — the integration dispatches the update event
+  immediately on `astro-consent:consent` for returning users, which GTM
+  interprets as "update arrived, stop waiting".
+- **CSP.** GTM's loader and the GCM default snippet are both inline.
+  `script-src 'unsafe-inline'` (or matching hashes) is required.
+- **Don't also gate the GTM snippet.** Wrapping the loader in a
+  `<ConsentScript category="analytics">` defeats GCM. The point of GCM is
+  that the loader *does* run pre-consent, but its tags fire in a
+  consent-aware degraded mode.
+
+## Alternative: block GTM until consent
+
+If you really can't run GTM pre-consent (e.g. your legal review requires it),
+gate the loader and skip GCM:
+
+```astro
+---
+import { ConsentScript } from '@zdenekkurecka/astro-consent/components';
+---
+<ConsentScript category="analytics">
+  {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;
+  j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+  f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-XXXXXXX');`}
+</ConsentScript>
+```
+
+You also won't get GCM's modelled conversions — accept this trade-off
+consciously.

--- a/docs/recipes/meta-pixel.md
+++ b/docs/recipes/meta-pixel.md
@@ -1,0 +1,124 @@
+# Meta Pixel (Facebook Pixel)
+
+Meta Pixel has no Google-Consent-Mode equivalent — the correct pattern is to
+block the entire `fbq` init until the user opts in. The `marketing` category
+is the conventional mapping.
+
+## Category mapping
+
+| Category    | Purpose                                   |
+| ----------- | ----------------------------------------- |
+| `marketing` | Meta Pixel init, `PageView`, conversions  |
+
+## Wiring
+
+### 1. Declare the category
+
+```ts
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import cookieConsent from '@zdenekkurecka/astro-consent';
+
+export default defineConfig({
+  integrations: [
+    cookieConsent({
+      version: 1,
+      categories: {
+        marketing: {
+          label: 'Marketing',
+          description: 'Used for targeted advertising.',
+          default: false,
+        },
+      },
+    }),
+  ],
+});
+```
+
+### 2. Gate the Pixel snippet
+
+```astro
+---
+import { ConsentScript } from '@zdenekkurecka/astro-consent/components';
+---
+<ConsentScript category="marketing">
+  {`!function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '1234567890');
+  fbq('track', 'PageView');`}
+</ConsentScript>
+```
+
+Everything up to and including `fbq('track', 'PageView')` must be inside the
+same gated script — `fbq` is defined by the init snippet, so splitting init
+and tracking across two separate `<ConsentScript>` blocks would leave the
+tracking call undefined.
+
+### 3. `<noscript>` pixel (optional)
+
+Meta's copy-paste snippet also includes a `<noscript>` image pixel:
+
+```html
+<noscript>
+  <img
+    height="1" width="1" style="display:none"
+    src="https://www.facebook.com/tr?id=1234567890&ev=PageView&noscript=1"
+    alt=""
+  />
+</noscript>
+```
+
+The `data-cc-*` system only intercepts `<script>` and `<iframe>` tags, so
+this `<img>` would fire regardless of consent if you included it as-is.
+Recommended options:
+
+- **Omit it.** Most users have JS enabled; the pixel's value for JS-less
+  traffic is low and likely not worth the consent complexity.
+- **Render it conditionally from a layout.** Set a cookie or check
+  `window.astroConsent?.get()?.categories.marketing` and render the
+  `<noscript>` block only when consent is granted. Beware: the decision has
+  to be made client-side, which means it won't actually help JS-disabled
+  users. In practice this just means "don't render it".
+
+## Gotchas
+
+- **Inline snippet requires `'unsafe-inline'`.** Meta's init is inline by
+  design, so strict CSP requires either `'unsafe-inline'` or a matching
+  hash/nonce. If that's not acceptable, move the init into an external file
+  served from your origin and use the `src` form of `<ConsentScript>`
+  instead.
+- **`fbq` leaks across navigations.** `<ClientRouter />` view transitions
+  don't tear the page down. Once `fbq` is initialised on a page load, it
+  stays initialised. This is fine; the pixel will just keep working until
+  the next real navigation.
+- **Revocation is one-way-ish.** `fbq('consent', 'revoke')` exists but does
+  not unload the script. If a user revokes marketing, call
+  `fbq?.('consent', 'revoke')` from an `astro-consent:change` listener —
+  subsequent `fbq('track', …)` calls will be deduped by Meta as
+  non-consenting. On the next full page load the script is blocked again.
+
+  ```astro
+  <script>
+    document.addEventListener('astro-consent:change', (e) => {
+      if (!e.detail.categories.marketing) {
+        // Revoke — further Pixel events will be discarded by Meta.
+        window.fbq?.('consent', 'revoke');
+      }
+    });
+  </script>
+  ```
+
+## Deduplication with server-side Conversions API
+
+If you're sending events to both Meta Pixel (client) and the Conversions API
+(server), pass a shared `eventID` so Meta can deduplicate. Consent gating
+doesn't affect this — just a reminder that the client-side `fbq('track', …)`
+call must include `{ eventID }`, and the server call must send the same one.
+This isn't consent-specific, but it's the #1 thing people get wrong when
+they re-wire their Pixel for consent.

--- a/packages/astro-consent/package.json
+++ b/packages/astro-consent/package.json
@@ -41,6 +41,10 @@
       "types": "./dist/client.d.ts",
       "default": "./dist/client.js"
     },
+    "./components": {
+      "types": "./dist/components/index.d.ts",
+      "default": "./dist/components/index.js"
+    },
     "./styles": "./dist/styles/base.css",
     "./styles/base.css": "./dist/styles/base.css",
     "./package.json": "./package.json"
@@ -55,7 +59,7 @@
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "pnpm run clean && tsc -p tsconfig.build.json && node scripts/copy-assets.mjs",
     "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
-    "dev:css": "node --watch-path=src/styles scripts/copy-assets.mjs",
+    "dev:css": "node --watch-path=src/styles --watch-path=src/components scripts/copy-assets.mjs",
     "prepublishOnly": "pnpm run build"
   },
   "peerDependencies": {

--- a/packages/astro-consent/scripts/copy-assets.mjs
+++ b/packages/astro-consent/scripts/copy-assets.mjs
@@ -14,9 +14,14 @@ const repoRoot = resolve(pkgRoot, '..', '..');
 
 const assets = [
   // [absolute source, absolute destination]
-  [resolve(pkgRoot, 'src/styles/base.css'), resolve(pkgRoot, 'dist/styles/base.css')],
-  [resolve(repoRoot, 'README.md'),          resolve(pkgRoot, 'README.md')],
-  [resolve(repoRoot, 'LICENSE'),            resolve(pkgRoot, 'LICENSE')],
+  [resolve(pkgRoot, 'src/styles/base.css'),                       resolve(pkgRoot, 'dist/styles/base.css')],
+  // `.astro` files are passed through verbatim — `tsc` doesn't understand
+  // them, so the build emits `dist/components/index.js` with a relative
+  // import into `./ConsentScript.astro` which Astro/Vite resolves in the
+  // consumer's project.
+  [resolve(pkgRoot, 'src/components/ConsentScript.astro'),        resolve(pkgRoot, 'dist/components/ConsentScript.astro')],
+  [resolve(repoRoot, 'README.md'),                                resolve(pkgRoot, 'README.md')],
+  [resolve(repoRoot, 'LICENSE'),                                  resolve(pkgRoot, 'LICENSE')],
 ];
 
 for (const [src, dst] of assets) {

--- a/packages/astro-consent/src/astro-shim.d.ts
+++ b/packages/astro-consent/src/astro-shim.d.ts
@@ -1,0 +1,9 @@
+// Lets `tsc` resolve `*.astro` imports while building this package. Astro
+// ships its own (richer) ambient declaration in consumer projects, so the
+// emitted .d.ts files rely on the user's Astro env to provide accurate
+// component types — this shim just keeps the local build from erroring.
+declare module '*.astro' {
+  import type { AstroComponentFactory } from 'astro/runtime/server/index.js';
+  const Component: AstroComponentFactory;
+  export default Component;
+}

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -31,6 +31,7 @@ import {
   handleModalTabTrap,
 } from './ui.js';
 import { activateBlockedResources, initScriptBlocker } from './scripts.js';
+import { buildGcmUpdatePayload } from './gcm.js';
 
 const LOG_PREFIX = '[astro-consent]';
 
@@ -45,6 +46,7 @@ function log(...args: unknown[]): void {
 
 let listenerAttached = false;
 let scriptBlockerAttached = false;
+let gcmListenerAttached = false;
 let consentFiredThisSession = false;
 
 /**
@@ -85,6 +87,33 @@ export function initConsentManager(config: SerializableConsentConfig): void {
     };
     document.addEventListener(CONSENT_EVENT, onConsent);
     document.addEventListener(CHANGE_EVENT, onConsent);
+  }
+
+  // Google Consent Mode v2: translate every consent event into
+  // `gtag('consent', 'update', …)`. Must be attached before the initial
+  // emit below so pages with pre-existing consent fire an update on load.
+  const gcmConfig = config.googleConsentMode;
+  if (gcmConfig && gcmConfig.enabled !== false && !gcmListenerAttached) {
+    gcmListenerAttached = true;
+    const onGcm = (e: CustomEvent<ConsentState>): void => {
+      const payload = buildGcmUpdatePayload(gcmConfig, e.detail.categories);
+      const gtag = (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag;
+      if (typeof gtag === 'function') {
+        gtag('consent', 'update', payload);
+        log('gcm update', payload);
+      } else {
+        // The head-inline snippet installs `gtag` globally. If it's missing,
+        // the snippet was stripped (CSP? custom head template?) — fall back to
+        // a raw dataLayer push so the update still lands once GTM loads.
+        const dl = (window as unknown as { dataLayer?: unknown[] }).dataLayer;
+        if (Array.isArray(dl)) {
+          dl.push(['consent', 'update', payload]);
+          log('gcm update (dataLayer fallback)', payload);
+        }
+      }
+    };
+    document.addEventListener(CONSENT_EVENT, onGcm);
+    document.addEventListener(CHANGE_EVENT, onGcm);
   }
 
   // Resolve UI text once per init: reads <html lang>, merges built-in

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -30,6 +30,7 @@ import {
   updateModalToggles,
   handleModalTabTrap,
 } from './ui.js';
+import { activateBlockedResources, initScriptBlocker } from './scripts.js';
 
 const LOG_PREFIX = '[astro-consent]';
 
@@ -43,6 +44,7 @@ function log(...args: unknown[]): void {
 }
 
 let listenerAttached = false;
+let scriptBlockerAttached = false;
 let consentFiredThisSession = false;
 
 /**
@@ -71,6 +73,19 @@ export function initConsentManager(config: SerializableConsentConfig): void {
   // Apply the configured localStorage key before any read/write so multiple
   // Astro apps on the same origin don't clobber each other's consent state.
   setStorageKey(config.storageKey);
+
+  // Declarative script blocking. Attach listeners + start the MutationObserver
+  // once per page lifecycle, BEFORE the initial CONSENT_EVENT emit below —
+  // otherwise pages with pre-existing consent would miss the first activation.
+  if (!scriptBlockerAttached) {
+    scriptBlockerAttached = true;
+    initScriptBlocker();
+    const onConsent = (e: CustomEvent<ConsentState>): void => {
+      activateBlockedResources(e.detail.categories);
+    };
+    document.addEventListener(CONSENT_EVENT, onConsent);
+    document.addEventListener(CHANGE_EVENT, onConsent);
+  }
 
   // Resolve UI text once per init: reads <html lang>, merges built-in
   // defaults → config.text → localeText[lang]. Passed to every injectUI call

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -157,24 +157,26 @@ export function initConsentManager(config: SerializableConsentConfig): void {
         case 'accept-all':
         case 'modal-accept-all': {
           log(`${action} →`, 'all categories: true');
+          const isUpdate = !needsConsent(config.version, config.maxAgeDays);
           const state = acceptAll(config);
           persist(state);
           hideBanner();
           hideModal();
           consentFiredThisSession = true;
-          emit(CONSENT_EVENT, state);
+          emit(isUpdate ? CHANGE_EVENT : CONSENT_EVENT, state);
           break;
         }
 
         case 'reject-all':
         case 'modal-reject-all': {
           log(`${action} →`, 'non-essential categories: false');
+          const isUpdate = !needsConsent(config.version, config.maxAgeDays);
           const state = rejectAll(config);
           persist(state);
           hideBanner();
           hideModal();
           consentFiredThisSession = true;
-          emit(CONSENT_EVENT, state);
+          emit(isUpdate ? CHANGE_EVENT : CONSENT_EVENT, state);
           break;
         }
 

--- a/packages/astro-consent/src/components/ConsentScript.astro
+++ b/packages/astro-consent/src/components/ConsentScript.astro
@@ -1,0 +1,82 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+
+/**
+ * Emits a consent-gated `<script type="text/plain">` placeholder that the
+ * runtime in `scripts.ts` activates once the given category is granted. The
+ * rendered markup is identical to what you'd write by hand:
+ *
+ *   <script is:inline type="text/plain"
+ *           data-cc-category="analytics"
+ *           data-cc-src="https://www.googletagmanager.com/gtag/js?id=G-XXX"></script>
+ *
+ * External form — provide `src`:
+ *
+ *   <ConsentScript category="analytics"
+ *                  src="https://www.googletagmanager.com/gtag/js?id=G-XXX" />
+ *
+ * Inline form — omit `src` and pass the body as a child expression:
+ *
+ *   <ConsentScript category="analytics">
+ *     {`gtag("js", new Date()); gtag("config", "G-XXX");`}
+ *   </ConsentScript>
+ *
+ * All remaining `<script>` attributes (`async`, `defer`, `nonce`, `integrity`,
+ * `crossorigin`, …) are forwarded to the placeholder and survive activation.
+ * `is:inline` is applied automatically so Astro leaves the placeholder body
+ * alone instead of bundling it as a module.
+ *
+ * Inline script bodies land in the placeholder verbatim — don't write HTML
+ * entity references (`&lt;`, `&amp;`, …) directly; use JS escape sequences
+ * (`"\u003c"`, `"\u0026"`) if you need those characters literally.
+ */
+
+type ScriptAttrs = Omit<HTMLAttributes<'script'>, 'src' | 'type' | 'is:inline'>;
+
+interface Props extends ScriptAttrs {
+  /** Consent category key that must be granted before this script loads. */
+  category: string;
+  /**
+   * External script URL. Omit to use the slot content as an inline script
+   * body (requires `'unsafe-inline'` or a CSP nonce).
+   */
+  src?: string;
+}
+
+const { category, src, ...rest } = Astro.props;
+
+// Astro renders slot content as HTML and escapes `"` / `'` / `<` / `>` / `&`.
+// A `<script>` placeholder body is JS source, not HTML, so the escaping must
+// be reversed before injection — otherwise `el.setAttribute('x', 'y')` in the
+// caller's source lands as `el.setAttribute(&#39;x&#39;, &#39;y&#39;)` and
+// syntax-errors the moment the runtime activates the script.
+function decodeScriptBody(s: string): string {
+  return s
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+const body = src ? '' : decodeScriptBody(await Astro.slots.render('default'));
+---
+{
+  src ? (
+    <script
+      is:inline
+      type="text/plain"
+      data-cc-category={category}
+      data-cc-src={src}
+      {...rest}
+    />
+  ) : (
+    <script
+      is:inline
+      type="text/plain"
+      data-cc-category={category}
+      set:html={body}
+      {...rest}
+    />
+  )
+}

--- a/packages/astro-consent/src/components/index.ts
+++ b/packages/astro-consent/src/components/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Public entry point for `@zdenekkurecka/astro-consent/components`.
+ *
+ * Keeps the `.astro` files internal implementation detail and gives users a
+ * single named-import surface:
+ *
+ *   import { ConsentScript } from '@zdenekkurecka/astro-consent/components';
+ */
+export { default as ConsentScript } from './ConsentScript.astro';

--- a/packages/astro-consent/src/gcm.ts
+++ b/packages/astro-consent/src/gcm.ts
@@ -1,0 +1,222 @@
+import type {
+  GoogleConsentDefaults,
+  GoogleConsentModeConfig,
+  GoogleConsentSignal,
+  GoogleConsentValue,
+} from './types.js';
+
+/**
+ * Known Google Consent Mode v2 signals. Anything outside this set is rejected
+ * by `validateGcmConfig` so typos in a user config fail at build time rather
+ * than silently being forwarded to `gtag`.
+ */
+export const GCM_SIGNALS = [
+  'ad_storage',
+  'ad_user_data',
+  'ad_personalization',
+  'analytics_storage',
+  'functionality_storage',
+  'personalization_storage',
+  'security_storage',
+] as const satisfies readonly GoogleConsentSignal[];
+
+const GCM_SIGNAL_SET = new Set<string>(GCM_SIGNALS);
+
+/**
+ * Validate a `GoogleConsentModeConfig` against the declared category keys.
+ * Throws a descriptive `Error` if:
+ *
+ *  - `mapping` is missing or empty
+ *  - A mapping key isn't a declared category (or `essential`)
+ *  - A mapped signal isn't a known GCM v2 signal
+ *  - A `defaults` / `regions` entry references an unknown signal or value
+ *  - `waitForUpdate` is negative / non-finite
+ */
+export function validateGcmConfig(
+  gcm: GoogleConsentModeConfig<string>,
+  categoryKeys: string[],
+): void {
+  const prefix = '[@zdenekkurecka/astro-consent] googleConsentMode';
+
+  if (!gcm.mapping || typeof gcm.mapping !== 'object') {
+    throw new Error(`${prefix}.mapping is required when googleConsentMode is enabled.`);
+  }
+
+  const mappingEntries = Object.entries(gcm.mapping);
+  if (mappingEntries.length === 0) {
+    throw new Error(
+      `${prefix}.mapping must not be empty — map at least one category to one or more GCM signals.`,
+    );
+  }
+
+  const allowedCats = new Set([...categoryKeys, 'essential']);
+  for (const [cat, signals] of mappingEntries) {
+    if (!allowedCats.has(cat)) {
+      throw new Error(
+        `${prefix}.mapping["${cat}"] references an unknown category. ` +
+          `Known categories: ${[...allowedCats].join(', ')}.`,
+      );
+    }
+    if (!Array.isArray(signals) || signals.length === 0) {
+      throw new Error(
+        `${prefix}.mapping["${cat}"] must be a non-empty array of GCM signals.`,
+      );
+    }
+    for (const s of signals) {
+      if (!GCM_SIGNAL_SET.has(s)) {
+        throw new Error(
+          `${prefix}.mapping["${cat}"] contains unknown signal "${s}". ` +
+            `Allowed signals: ${GCM_SIGNALS.join(', ')}.`,
+        );
+      }
+    }
+  }
+
+  if (gcm.defaults) {
+    assertDefaults(gcm.defaults, `${prefix}.defaults`);
+  }
+
+  if (gcm.regions) {
+    for (const [region, value] of Object.entries(gcm.regions)) {
+      if (!region) {
+        throw new Error(`${prefix}.regions contains an empty key.`);
+      }
+      if (typeof value === 'string') {
+        assertValue(value, `${prefix}.regions["${region}"]`);
+      } else if (value && typeof value === 'object') {
+        assertDefaults(value, `${prefix}.regions["${region}"]`);
+      } else {
+        throw new Error(
+          `${prefix}.regions["${region}"] must be a string ("granted"/"denied") or an object.`,
+        );
+      }
+    }
+  }
+
+  if (gcm.waitForUpdate !== undefined) {
+    if (
+      typeof gcm.waitForUpdate !== 'number' ||
+      !Number.isFinite(gcm.waitForUpdate) ||
+      gcm.waitForUpdate < 0
+    ) {
+      throw new Error(`${prefix}.waitForUpdate must be a non-negative number (ms).`);
+    }
+  }
+}
+
+function assertDefaults(obj: GoogleConsentDefaults, path: string): void {
+  for (const [signal, value] of Object.entries(obj)) {
+    if (!GCM_SIGNAL_SET.has(signal)) {
+      throw new Error(
+        `${path}["${signal}"] is not a known GCM signal. ` +
+          `Allowed signals: ${GCM_SIGNALS.join(', ')}.`,
+      );
+    }
+    if (value === undefined) continue;
+    assertValue(value, `${path}["${signal}"]`);
+  }
+}
+
+function assertValue(value: unknown, path: string): void {
+  if (value !== 'granted' && value !== 'denied') {
+    throw new Error(`${path} must be "granted" or "denied" (got ${JSON.stringify(value)}).`);
+  }
+}
+
+/**
+ * Build the inline snippet that pre-declares GCM defaults at the top of
+ * `<head>`. The snippet:
+ *
+ *  1. Initializes `window.dataLayer` and a global `gtag(…)` helper.
+ *  2. Calls `gtag('consent', 'default', { …denied…, wait_for_update })` with
+ *     every mapped signal set to `"denied"` (or the user-provided default).
+ *  3. Emits one additional `gtag('consent', 'default', { …, region: ['XX'] })`
+ *     per `regions` entry so CCPA-style opt-out regions can start granted.
+ *  4. Forwards `ads_data_redaction` / `url_passthrough` via `gtag('set', …)`.
+ */
+export function buildGcmDefaultSnippet(gcm: GoogleConsentModeConfig<string>): string {
+  const mappedSignals = collectMappedSignals(gcm);
+  const waitForUpdate = gcm.waitForUpdate ?? 500;
+
+  const baseDefaults: Record<string, GoogleConsentValue> = {};
+  for (const signal of mappedSignals) {
+    baseDefaults[signal] = 'denied';
+  }
+  if (gcm.defaults) {
+    for (const [signal, value] of Object.entries(gcm.defaults)) {
+      if (value !== undefined) baseDefaults[signal] = value;
+    }
+  }
+
+  const lines: string[] = [
+    'window.dataLayer = window.dataLayer || [];',
+    'function gtag(){dataLayer.push(arguments);}',
+    `gtag('consent','default',${JSON.stringify({ ...baseDefaults, wait_for_update: waitForUpdate })});`,
+  ];
+
+  if (gcm.regions) {
+    for (const [region, value] of Object.entries(gcm.regions)) {
+      const regionDefaults: Record<string, GoogleConsentValue> = {};
+      if (typeof value === 'string') {
+        for (const signal of mappedSignals) {
+          regionDefaults[signal] = value;
+        }
+      } else {
+        for (const [signal, v] of Object.entries(value)) {
+          if (v !== undefined) regionDefaults[signal] = v;
+        }
+      }
+      lines.push(
+        `gtag('consent','default',${JSON.stringify({ ...regionDefaults, region: [region] })});`,
+      );
+    }
+  }
+
+  if (gcm.adsDataRedaction !== undefined) {
+    lines.push(`gtag('set','ads_data_redaction',${gcm.adsDataRedaction ? 'true' : 'false'});`);
+  }
+  if (gcm.urlPassthrough !== undefined) {
+    lines.push(`gtag('set','url_passthrough',${gcm.urlPassthrough ? 'true' : 'false'});`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Return every GCM signal mentioned in any mapping entry. Used by the default
+ * snippet (to decide which signals to pre-declare) and by the runtime update
+ * path (to decide which signals to recompute on each consent event).
+ */
+export function collectMappedSignals(
+  gcm: GoogleConsentModeConfig<string>,
+): GoogleConsentSignal[] {
+  const out = new Set<GoogleConsentSignal>();
+  for (const signals of Object.values(gcm.mapping)) {
+    if (!signals) continue;
+    for (const s of signals) out.add(s);
+  }
+  return [...out];
+}
+
+/**
+ * Compute the `gtag('consent', 'update', …)` payload for a given set of
+ * granted categories. AND semantics: a signal is granted only when every
+ * category that maps to it is granted. Signals absent from `mapping` are
+ * omitted — the caller must never overwrite them.
+ */
+export function buildGcmUpdatePayload(
+  gcm: GoogleConsentModeConfig<string>,
+  categories: Record<string, boolean>,
+): Record<string, GoogleConsentValue> {
+  const result: Record<string, GoogleConsentValue> = {};
+  for (const signal of collectMappedSignals(gcm)) {
+    result[signal] = 'granted';
+  }
+  for (const [cat, signals] of Object.entries(gcm.mapping)) {
+    if (!signals) continue;
+    if (!categories[cat]) {
+      for (const s of signals) result[s] = 'denied';
+    }
+  }
+  return result;
+}

--- a/packages/astro-consent/src/index.ts
+++ b/packages/astro-consent/src/index.ts
@@ -6,4 +6,9 @@ export type {
   ConsentCategoryText,
   ConsentText,
   ConsentAPI,
+  GoogleConsentModeConfig,
+  GoogleConsentSignal,
+  GoogleConsentValue,
+  GoogleConsentDefaults,
+  GoogleConsentRegionValue,
 } from './types.js';

--- a/packages/astro-consent/src/index.ts
+++ b/packages/astro-consent/src/index.ts
@@ -6,9 +6,13 @@ export type {
   ConsentCategoryText,
   ConsentText,
   ConsentAPI,
+  ConsentEvent,
+  ConsentKeys,
+  ResolvedConsentKeys,
   GoogleConsentModeConfig,
   GoogleConsentSignal,
   GoogleConsentValue,
   GoogleConsentDefaults,
   GoogleConsentRegionValue,
 } from './types.js';
+export { CONSENT_EVENT, CHANGE_EVENT } from './types.js';

--- a/packages/astro-consent/src/integration.ts
+++ b/packages/astro-consent/src/integration.ts
@@ -1,5 +1,6 @@
 import type { AstroIntegration } from 'astro';
 import type { ConsentConfig, SerializableConsentConfig } from './types.js';
+import { buildGcmDefaultSnippet, validateGcmConfig } from './gcm.js';
 import { vitePluginConsentConfig } from './virtual-config.js';
 
 export default function cookieConsent<K extends string = string>(
@@ -21,6 +22,11 @@ export default function cookieConsent<K extends string = string>(
     );
   }
 
+  const gcm = userConfig.googleConsentMode;
+  if (gcm && gcm.enabled !== false) {
+    validateGcmConfig(gcm, Object.keys(userConfig.categories));
+  }
+
   const serializableConfig: SerializableConsentConfig<K> = {
     version: userConfig.version,
     categories: userConfig.categories,
@@ -31,6 +37,7 @@ export default function cookieConsent<K extends string = string>(
     ui: userConfig.ui,
     text: userConfig.text,
     localeText: userConfig.localeText,
+    googleConsentMode: userConfig.googleConsentMode,
   };
 
   return {
@@ -58,6 +65,14 @@ export default function cookieConsent<K extends string = string>(
         // a hashed <script type="module" src="..."> — not inline — so the
         // integration also works under strict script-src CSP.
         injectScript('page', 'import "virtual:astro-consent/init";');
+
+        // Google Consent Mode v2: inject the default-denied snippet inline
+        // at the top of <head> so `gtag('consent', 'default', …)` runs before
+        // any downstream GTM/gtag.js. This is the one case where we emit an
+        // inline <script> — opt-in and documented as a CSP caveat.
+        if (gcm && gcm.enabled !== false) {
+          injectScript('head-inline', buildGcmDefaultSnippet(gcm));
+        }
       },
     },
   };

--- a/packages/astro-consent/src/integration.ts
+++ b/packages/astro-consent/src/integration.ts
@@ -2,7 +2,9 @@ import type { AstroIntegration } from 'astro';
 import type { ConsentConfig, SerializableConsentConfig } from './types.js';
 import { vitePluginConsentConfig } from './virtual-config.js';
 
-export default function cookieConsent(userConfig?: ConsentConfig): AstroIntegration {
+export default function cookieConsent<K extends string = string>(
+  userConfig?: ConsentConfig<K>,
+): AstroIntegration {
   if (
     !userConfig ||
     typeof userConfig.version !== 'number' ||
@@ -19,7 +21,7 @@ export default function cookieConsent(userConfig?: ConsentConfig): AstroIntegrat
     );
   }
 
-  const serializableConfig: SerializableConsentConfig = {
+  const serializableConfig: SerializableConsentConfig<K> = {
     version: userConfig.version,
     categories: userConfig.categories,
     cookiePolicy: userConfig.cookiePolicy,

--- a/packages/astro-consent/src/scripts.ts
+++ b/packages/astro-consent/src/scripts.ts
@@ -28,9 +28,11 @@ const IFRAME_SELECTOR = 'iframe[data-cc-category][data-cc-src]:not([src])';
 /**
  * Attributes we deliberately drop when cloning a blocked script into a live
  * one. `type` would re-block it; `data-cc-src` is the source-of-truth we've
- * already copied into `src`.
+ * already copied into `src`. `nonce` is skipped here because the content
+ * attribute is hidden post-parse (CSP L3) — we copy it via the `.nonce`
+ * IDL property below instead.
  */
-const SCRIPT_SKIP_ATTRS = new Set(['type', 'data-cc-src']);
+const SCRIPT_SKIP_ATTRS = new Set(['type', 'data-cc-src', 'nonce']);
 
 function isActivated(el: Element): boolean {
   return el.getAttribute(ACTIVATED_ATTR) === 'true';
@@ -41,9 +43,13 @@ function isActivated(el: Element): boolean {
  * browser executes it. A fresh element is required — mutating `type` on an
  * existing script does not retroactively trigger execution.
  *
- * All other attributes (async, defer, nonce, integrity, crossorigin, …) are
+ * All other attributes (async, defer, integrity, crossorigin, …) are
  * preserved, so CSP nonces set on the placeholder flow through to the
- * injected script.
+ * injected script. `nonce` is special-cased: browsers hide the content
+ * attribute post-parse for security (CSP L3), so `getAttribute('nonce')`
+ * returns an empty string and only the `.nonce` IDL property holds the
+ * real value. Copy via the property so the injected script still matches
+ * the page CSP.
  */
 function activateScript(oldScript: HTMLScriptElement): void {
   if (isActivated(oldScript)) return;
@@ -53,6 +59,7 @@ function activateScript(oldScript: HTMLScriptElement): void {
     if (SCRIPT_SKIP_ATTRS.has(attr.name)) continue;
     newScript.setAttribute(attr.name, attr.value);
   }
+  if (oldScript.nonce) newScript.nonce = oldScript.nonce;
 
   const src = oldScript.getAttribute('data-cc-src');
   if (src) {

--- a/packages/astro-consent/src/scripts.ts
+++ b/packages/astro-consent/src/scripts.ts
@@ -1,0 +1,147 @@
+import { readConsent } from './consent.js';
+
+/**
+ * Declarative third-party script blocking.
+ *
+ * Authors mark scripts / iframes as gated with consent categories:
+ *
+ *   <script type="text/plain" data-cc-category="analytics"
+ *           data-cc-src="https://www.googletagmanager.com/gtag/js?id=G-XXX"></script>
+ *
+ *   <script type="text/plain" data-cc-category="analytics">
+ *     // inline tracker body
+ *   </script>
+ *
+ *   <iframe data-cc-category="marketing" data-cc-src="https://www.youtube.com/embed/…"></iframe>
+ *
+ * The browser treats `type="text/plain"` scripts and src-less iframes as inert
+ * data islands. When the matching consent category is granted we replace the
+ * placeholder with a live `<script>` / copy `data-cc-src` into `src`, which
+ * triggers execution. Activation is irreversible within the page lifecycle —
+ * see README for the revocation caveat.
+ */
+
+const ACTIVATED_ATTR = 'data-cc-activated';
+const SCRIPT_SELECTOR = 'script[type="text/plain"][data-cc-category]';
+const IFRAME_SELECTOR = 'iframe[data-cc-category][data-cc-src]:not([src])';
+
+/**
+ * Attributes we deliberately drop when cloning a blocked script into a live
+ * one. `type` would re-block it; `data-cc-src` is the source-of-truth we've
+ * already copied into `src`.
+ */
+const SCRIPT_SKIP_ATTRS = new Set(['type', 'data-cc-src']);
+
+function isActivated(el: Element): boolean {
+  return el.getAttribute(ACTIVATED_ATTR) === 'true';
+}
+
+/**
+ * Replace a blocked `<script type="text/plain">` with a live `<script>` so the
+ * browser executes it. A fresh element is required — mutating `type` on an
+ * existing script does not retroactively trigger execution.
+ *
+ * All other attributes (async, defer, nonce, integrity, crossorigin, …) are
+ * preserved, so CSP nonces set on the placeholder flow through to the
+ * injected script.
+ */
+function activateScript(oldScript: HTMLScriptElement): void {
+  if (isActivated(oldScript)) return;
+
+  const newScript = document.createElement('script');
+  for (const attr of Array.from(oldScript.attributes)) {
+    if (SCRIPT_SKIP_ATTRS.has(attr.name)) continue;
+    newScript.setAttribute(attr.name, attr.value);
+  }
+
+  const src = oldScript.getAttribute('data-cc-src');
+  if (src) {
+    newScript.src = src;
+  } else {
+    // Inline body: re-inject verbatim. This is an inline script and therefore
+    // requires `'unsafe-inline'` or a nonce under strict CSP — prefer the
+    // `data-cc-src` external form when possible.
+    newScript.text = oldScript.textContent ?? '';
+  }
+  newScript.setAttribute(ACTIVATED_ATTR, 'true');
+
+  // Mark the old one before removing it — defensive in case replaceChild
+  // fails and the element stays in the DOM for some reason.
+  oldScript.setAttribute(ACTIVATED_ATTR, 'true');
+  oldScript.parentNode?.replaceChild(newScript, oldScript);
+}
+
+function activateIframe(iframe: HTMLIFrameElement): void {
+  if (isActivated(iframe)) return;
+  const src = iframe.getAttribute('data-cc-src');
+  if (!src) return;
+  iframe.setAttribute(ACTIVATED_ATTR, 'true');
+  iframe.setAttribute('src', src);
+}
+
+function isGranted(el: Element, categories: Record<string, boolean>): boolean {
+  const cat = el.getAttribute('data-cc-category');
+  return !!cat && categories[cat] === true;
+}
+
+/**
+ * One-shot scan: activate every blocked script/iframe whose category is
+ * currently granted. Safe to call repeatedly — already-activated scripts are
+ * removed from the DOM and already-activated iframes are filtered via the
+ * `data-cc-activated` marker.
+ */
+export function activateBlockedResources(categories: Record<string, boolean>): void {
+  const scripts = document.querySelectorAll<HTMLScriptElement>(SCRIPT_SELECTOR);
+  for (const s of scripts) {
+    if (isGranted(s, categories)) activateScript(s);
+  }
+
+  const iframes = document.querySelectorAll<HTMLIFrameElement>(IFRAME_SELECTOR);
+  for (const f of iframes) {
+    if (!isActivated(f) && isGranted(f, categories)) activateIframe(f);
+  }
+}
+
+let observer: MutationObserver | null = null;
+
+/**
+ * Observe the DOM for blocked elements inserted after initial consent (e.g.
+ * via client-side routing or ad-hoc DOM manipulation) and activate them on
+ * the fly if the relevant category is already granted. Idempotent — calling
+ * more than once is a no-op.
+ */
+export function initScriptBlocker(): void {
+  if (observer || typeof MutationObserver === 'undefined') return;
+
+  observer = new MutationObserver((mutations) => {
+    const state = readConsent();
+    if (!state) return;
+    const categories = state.categories;
+
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (!(node instanceof Element)) continue;
+
+        if (node.matches(SCRIPT_SELECTOR) && isGranted(node, categories)) {
+          activateScript(node as HTMLScriptElement);
+        } else if (node.matches(IFRAME_SELECTOR) && isGranted(node, categories)) {
+          activateIframe(node as HTMLIFrameElement);
+        }
+
+        // Descendants of a newly-inserted subtree (e.g. a fragment attached
+        // in one shot) don't generate their own mutation records — walk them
+        // here so nested blocked elements still get picked up.
+        const nestedScripts = node.querySelectorAll<HTMLScriptElement>(SCRIPT_SELECTOR);
+        for (const s of nestedScripts) {
+          if (isGranted(s, categories)) activateScript(s);
+        }
+        const nestedIframes = node.querySelectorAll<HTMLIFrameElement>(IFRAME_SELECTOR);
+        for (const f of nestedIframes) {
+          if (!isActivated(f) && isGranted(f, categories)) activateIframe(f);
+        }
+      }
+    }
+  });
+
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+}

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -39,8 +39,11 @@ export interface ConsentCategoryText {
  * All fields are optional. Unspecified fields fall back to the built-in
  * English defaults, so you only need to provide the strings you want to
  * change.
+ *
+ * When the parent `ConsentConfig` is given a literal category-key union,
+ * `categories` autocompletes and typo-checks against that union.
  */
-export interface ConsentText {
+export interface ConsentText<K extends string = string> {
   // Banner
   bannerText?: string;
   acceptAll?: string;
@@ -58,12 +61,12 @@ export interface ConsentText {
   essentialBadge?: string;
 
   /** Per-category label/description overrides, keyed by category key. */
-  categories?: Record<string, ConsentCategoryText>;
+  categories?: Partial<Record<K, ConsentCategoryText>>;
 }
 
-export interface ConsentConfig {
+export interface ConsentConfig<K extends string = string> {
   version: number;
-  categories: Record<string, ConsentCategory>;
+  categories: Record<K, ConsentCategory>;
   cookiePolicy?: CookiePolicyLink;
 
   /**
@@ -100,7 +103,7 @@ export interface ConsentConfig {
   ui?: ConsentUIConfig;
 
   /** Single-language text overrides, or shared fallback for `localeText`. */
-  text?: ConsentText;
+  text?: ConsentText<K>;
 
   /**
    * Per-locale text overrides. Keys are BCP 47 language tags that match the
@@ -109,25 +112,25 @@ export interface ConsentConfig {
    * Resolution order at runtime: exact match → primary subtag → `text` →
    * built-in defaults.
    */
-  localeText?: Record<string, ConsentText>;
+  localeText?: Record<string, ConsentText<K>>;
 }
 
-export interface ConsentState {
+export interface ConsentState<K extends string = string> {
   version: number;
   timestamp: number;
-  categories: Record<string, boolean>;
+  categories: Record<K, boolean>;
 }
 
-export interface SerializableConsentConfig {
+export interface SerializableConsentConfig<K extends string = string> {
   version: number;
-  categories: Record<string, ConsentCategory>;
+  categories: Record<K, ConsentCategory>;
   cookiePolicy?: CookiePolicyLink;
   storageKey?: string;
   maxAgeDays?: number;
   debug?: boolean;
   ui?: ConsentUIConfig;
-  text?: ConsentText;
-  localeText?: Record<string, ConsentText>;
+  text?: ConsentText<K>;
+  localeText?: Record<string, ConsentText<K>>;
 }
 
 /**
@@ -199,7 +202,7 @@ export const CONSENT_EVENT = 'astro-consent:consent';
  */
 export const CHANGE_EVENT = 'astro-consent:change';
 
-export type ConsentEvent = CustomEvent<ConsentState>;
+export type ConsentEvent<K extends string = string> = CustomEvent<ConsentState<K>>;
 
 declare global {
   interface DocumentEventMap {

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -261,9 +261,9 @@ export interface ConsentDebugSnapshot {
   needsConsent: boolean;
 }
 
-export interface ConsentAPI {
+export interface ConsentAPI<K extends string = string> {
   /** Returns the currently stored consent state, or `null` if none. */
-  get(): ConsentState | null;
+  get(): ConsentState<K> | null;
   /**
    * Merge a partial category map into the current state and persist it.
    *
@@ -273,7 +273,7 @@ export interface ConsentAPI {
    * state and dispatch `astro-consent:change` instead. The `essential`
    * category is always forced to `true`.
    */
-  set(categories: Partial<Record<string, boolean>>): void;
+  set(categories: Partial<Record<K, boolean>>): void;
   /** Clear the stored consent and re-show the banner. */
   reset(): void;
   /** Show the consent banner. */
@@ -317,15 +317,50 @@ export const CHANGE_EVENT = 'astro-consent:change';
 
 export type ConsentEvent<K extends string = string> = CustomEvent<ConsentState<K>>;
 
+/**
+ * Marker interface for consumers to opt into typed category keys across
+ * `window.astroConsent` and the `astro-consent:consent` / `astro-consent:change`
+ * event listeners.
+ *
+ * Augment it in a project-level `.d.ts` file with the category keys you
+ * declared in `cookieConsent({ categories: … })`:
+ *
+ * ```ts
+ * // src/astro-consent.d.ts
+ * declare module '@zdenekkurecka/astro-consent' {
+ *   interface ConsentKeys {
+ *     analytics: true;
+ *     marketing: true;
+ *   }
+ * }
+ * export {};
+ * ```
+ *
+ * With the augmentation in place, `e.detail.categories.*` and
+ * `window.astroConsent?.get()?.categories.*` narrow to the declared keys and
+ * typos error at compile time. Without it, both fall back to
+ * `Record<string, boolean>` — same as before.
+ */
+export interface ConsentKeys {}
+
+/**
+ * Resolves to the consumer-declared key union when `ConsentKeys` has been
+ * augmented, otherwise falls back to `string` so the default behaviour is
+ * non-breaking.
+ */
+export type ResolvedConsentKeys = [keyof ConsentKeys] extends [never]
+  ? string
+  : Extract<keyof ConsentKeys, string>;
+
 declare global {
   interface DocumentEventMap {
-    'astro-consent:consent': ConsentEvent;
-    'astro-consent:change': ConsentEvent;
+    'astro-consent:consent': ConsentEvent<ResolvedConsentKeys>;
+    'astro-consent:change': ConsentEvent<ResolvedConsentKeys>;
   }
 
   interface Window {
-    astroConsent?: ConsentAPI;
+    astroConsent?: ConsentAPI<ResolvedConsentKeys>;
     /** @deprecated Use `astroConsent` instead. */
-    zdenekkureckaConsent?: ConsentAPI;
+    zdenekkureckaConsent?: ConsentAPI<ResolvedConsentKeys>;
   }
 }

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -4,6 +4,108 @@ export interface ConsentCategory {
   default: boolean;
 }
 
+/**
+ * Google Consent Mode v2 signals.
+ *
+ * @see https://developers.google.com/tag-platform/security/concepts/consent-mode
+ */
+export type GoogleConsentSignal =
+  | 'ad_storage'
+  | 'ad_user_data'
+  | 'ad_personalization'
+  | 'analytics_storage'
+  | 'functionality_storage'
+  | 'personalization_storage'
+  | 'security_storage';
+
+/** A Google Consent Mode v2 signal value. */
+export type GoogleConsentValue = 'granted' | 'denied';
+
+/**
+ * Per-signal default overrides, used both for the global default snippet and
+ * for regional overrides.
+ */
+export type GoogleConsentDefaults = Partial<
+  Record<GoogleConsentSignal, GoogleConsentValue>
+>;
+
+/**
+ * Regional default: either a single value applied to every mapped signal, or
+ * a per-signal map.
+ */
+export type GoogleConsentRegionValue = GoogleConsentValue | GoogleConsentDefaults;
+
+/**
+ * Google Consent Mode v2 configuration.
+ *
+ * When set, the integration injects an inline snippet at the top of `<head>`
+ * that bootstraps `window.dataLayer` + `gtag` and calls
+ * `gtag('consent', 'default', {...})` before any downstream GTM / gtag.js
+ * loads. Subsequent `astro-consent:consent` and `astro-consent:change` events
+ * automatically fire `gtag('consent', 'update', {...})` with the signals
+ * derived from `mapping`.
+ *
+ * The default snippet is inline and therefore requires `'unsafe-inline'` or a
+ * matching hash under strict CSP. This is opt-in — if you don't configure
+ * `googleConsentMode`, the integration stays strict-CSP-safe.
+ */
+export interface GoogleConsentModeConfig<K extends string = string> {
+  /**
+   * Set to `false` to temporarily disable the integration without deleting
+   * config. Treated the same as omitting `googleConsentMode`.
+   *
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Map each consent category key to one or more Google Consent Mode v2
+   * signals. A signal is granted only when **every** category that maps to it
+   * is granted, and denied otherwise. Signals that aren't mentioned in any
+   * mapping are never updated by the integration.
+   *
+   * @example
+   *   mapping: {
+   *     analytics: ['analytics_storage'],
+   *     marketing: ['ad_storage', 'ad_user_data', 'ad_personalization'],
+   *   }
+   */
+  mapping: Partial<Record<K | 'essential', GoogleConsentSignal[]>>;
+
+  /**
+   * Millisecond hint passed to GTM via `wait_for_update` in the default
+   * snippet. Tells GTM how long to delay firing tags while it waits for the
+   * first `gtag('consent', 'update', …)` call.
+   *
+   * @default 500
+   */
+  waitForUpdate?: number;
+
+  /**
+   * Override the initial signal values. Signals not listed here default to
+   * `"denied"` to stay compliant with GDPR/ePrivacy.
+   */
+  defaults?: GoogleConsentDefaults;
+
+  /**
+   * Regional overrides of `defaults`, keyed by ISO 3166-1 alpha-2 region
+   * codes (e.g. `"US"`) or subdivisions (e.g. `"US-CA"`). Each entry can be
+   * either a single value applied to every mapped signal, or a per-signal
+   * object. Emitted as additional `gtag('consent', 'default', { ..., region:
+   * ['XX'] })` calls after the global defaults.
+   *
+   * @example
+   *   regions: { US: 'granted', BR: { ad_storage: 'denied' } }
+   */
+  regions?: Record<string, GoogleConsentRegionValue>;
+
+  /** Forwarded as `gtag('set', 'ads_data_redaction', <bool>)`. */
+  adsDataRedaction?: boolean;
+
+  /** Forwarded as `gtag('set', 'url_passthrough', <bool>)`. */
+  urlPassthrough?: boolean;
+}
+
 export interface CookiePolicyLink {
   url: string;
   label?: string;
@@ -113,6 +215,16 @@ export interface ConsentConfig<K extends string = string> {
    * built-in defaults.
    */
   localeText?: Record<string, ConsentText<K>>;
+
+  /**
+   * Google Consent Mode v2 integration. When configured, an inline snippet
+   * is injected at the top of `<head>` to pre-declare denied defaults before
+   * any GTM/gtag.js loads, and consent events automatically translate into
+   * `gtag('consent', 'update', …)` calls.
+   *
+   * Opt-in — omit this to keep the integration strict-CSP safe.
+   */
+  googleConsentMode?: GoogleConsentModeConfig<K>;
 }
 
 export interface ConsentState<K extends string = string> {
@@ -131,6 +243,7 @@ export interface SerializableConsentConfig<K extends string = string> {
   ui?: ConsentUIConfig;
   text?: ConsentText<K>;
   localeText?: Record<string, ConsentText<K>>;
+  googleConsentMode?: GoogleConsentModeConfig<K>;
 }
 
 /**

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -434,8 +434,13 @@ export function isModalVisible(): boolean {
   return document.getElementById(MODAL_ID)?.classList.contains('cc-visible') ?? false;
 }
 
+// Scoped to `#cc-modal input[data-cc-category]` so declarative script-blocking
+// markup (which reuses `data-cc-category` on <script>/<iframe> elements)
+// doesn't leak into modal state reads.
+const MODAL_TOGGLE_SELECTOR = `#${MODAL_ID} input[data-cc-category]`;
+
 export function updateModalToggles(categories: Record<string, boolean>): void {
-  const inputs = document.querySelectorAll<HTMLInputElement>('[data-cc-category]');
+  const inputs = document.querySelectorAll<HTMLInputElement>(MODAL_TOGGLE_SELECTOR);
   for (const input of inputs) {
     const key = input.getAttribute('data-cc-category');
     if (key && !input.disabled) {
@@ -446,7 +451,7 @@ export function updateModalToggles(categories: Record<string, boolean>): void {
 
 export function getModalSelections(): Record<string, boolean> {
   const selections: Record<string, boolean> = {};
-  const inputs = document.querySelectorAll<HTMLInputElement>('[data-cc-category]');
+  const inputs = document.querySelectorAll<HTMLInputElement>(MODAL_TOGGLE_SELECTOR);
   for (const input of inputs) {
     const key = input.getAttribute('data-cc-category');
     if (key && key !== 'essential') {

--- a/packages/astro-consent/tsconfig.json
+++ b/packages/astro-consent/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "src",
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
 }

--- a/playground/astro.config.mjs
+++ b/playground/astro.config.mjs
@@ -24,6 +24,19 @@ export default defineConfig({
           default: false,
         },
       },
+      googleConsentMode: {
+        enabled: true,
+        mapping: {
+          analytics: ['analytics_storage'],
+          marketing: ['ad_storage', 'ad_user_data', 'ad_personalization'],
+        },
+        waitForUpdate: 500,
+        regions: {
+          US: 'granted',
+        },
+        adsDataRedaction: true,
+        urlPassthrough: false,
+      },
     }),
   ],
 });

--- a/playground/e2e/component.spec.ts
+++ b/playground/e2e/component.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { clearConsent } from './helpers';
+
+test.describe('ConsentScript component', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/component');
+    await clearConsent(page);
+    await page.reload();
+  });
+
+  test('renders inert placeholders before consent', async ({ page }) => {
+    await expect(page.locator('#cc-banner')).toHaveClass(/cc-visible/);
+
+    expect(await page.evaluate(() => (window as any).__ccComponentInlineLoaded)).toBeUndefined();
+    expect(await page.evaluate(() => (window as any).__ccComponentExternalLoaded)).toBeUndefined();
+    expect(await page.evaluate(() => (window as any).__ccComponentMarketingLoaded)).toBeUndefined();
+
+    // Placeholder <script> tags must still carry the inert type attr so the
+    // browser never executes them until the runtime rewrites them.
+    const inert = await page.locator('script[type="text/plain"][data-cc-category]').count();
+    expect(inert).toBeGreaterThanOrEqual(3);
+  });
+
+  test('accept-all activates every gated script', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+
+    await expect(page.locator('#c-inline-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#c-ext-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#c-marketing-marker')).toHaveAttribute('data-loaded', 'true');
+
+    expect(await page.evaluate(() => (window as any).__ccComponentInlineLoaded)).toBe(true);
+    expect(await page.evaluate(() => (window as any).__ccComponentExternalLoaded)).toBe(true);
+    expect(await page.evaluate(() => (window as any).__ccComponentMarketingLoaded)).toBe(true);
+  });
+
+  test('denied category stays blocked', async ({ page }) => {
+    await page.locator('[data-cc=manage]').click();
+    await page.locator('label.cc-toggle:has([data-cc-category=analytics])').click();
+    await page.locator('[data-cc=save-preferences]').click();
+
+    await expect(page.locator('#c-inline-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#c-marketing-marker')).toHaveAttribute('data-loaded', 'false');
+
+    expect(await page.evaluate(() => (window as any).__ccComponentMarketingLoaded)).toBeUndefined();
+  });
+
+  test('passes through script attributes such as async', async ({ page }) => {
+    // The marketing ConsentScript is declared with `async`. After activation
+    // the forwarded attribute should still be present on the live <script>.
+    await page.locator('[data-cc=accept-all]').click();
+
+    await expect(page.locator('#c-marketing-marker')).toHaveAttribute('data-loaded', 'true');
+
+    const hasAsync = await page.evaluate(() => {
+      const activated = document.querySelectorAll<HTMLScriptElement>(
+        'script[data-cc-activated="true"][data-cc-category="marketing"]',
+      );
+      return Array.from(activated).some((s) => s.async === true);
+    });
+    expect(hasAsync).toBe(true);
+  });
+});

--- a/playground/e2e/gcm.spec.ts
+++ b/playground/e2e/gcm.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect, type Page } from '@playwright/test';
+import { clearConsent } from './helpers';
+
+/**
+ * Collect every entry in `window.dataLayer`, normalizing the `arguments`-shaped
+ * objects pushed by the `gtag(...)` helper into plain arrays so Playwright can
+ * assert against them.
+ */
+async function readDataLayer(page: Page): Promise<unknown[]> {
+  return page.evaluate(() => {
+    const dl = (window as any).dataLayer ?? [];
+    return dl.map((entry: any) => {
+      if (entry && typeof entry === 'object' && typeof entry.length === 'number') {
+        return Array.from(entry);
+      }
+      return entry;
+    });
+  });
+}
+
+function findConsentCalls(
+  entries: unknown[],
+  command: 'default' | 'update',
+): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  for (const entry of entries) {
+    if (!Array.isArray(entry)) continue;
+    if (entry[0] === 'consent' && entry[1] === command && entry[2]) {
+      out.push(entry[2] as Record<string, unknown>);
+    }
+  }
+  return out;
+}
+
+test.describe('Google Consent Mode v2', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/gcm');
+    await clearConsent(page);
+    await page.reload();
+  });
+
+  test('head-inline snippet sets denied defaults + wait_for_update', async ({ page }) => {
+    const entries = await readDataLayer(page);
+    const defaults = findConsentCalls(entries, 'default');
+
+    // Global denied defaults + one regional override for US.
+    expect(defaults).toHaveLength(2);
+
+    const global = defaults[0];
+    expect(global).toMatchObject({
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'denied',
+      wait_for_update: 500,
+    });
+    expect(global).not.toHaveProperty('region');
+
+    const usOverride = defaults[1];
+    expect(usOverride).toMatchObject({
+      ad_storage: 'granted',
+      ad_user_data: 'granted',
+      ad_personalization: 'granted',
+      analytics_storage: 'granted',
+      region: ['US'],
+    });
+  });
+
+  test('ads_data_redaction is forwarded via gtag("set", …)', async ({ page }) => {
+    const entries = await readDataLayer(page);
+    const setCalls = entries.filter(
+      (e): e is unknown[] => Array.isArray(e) && e[0] === 'set',
+    );
+    const redaction = setCalls.find((c) => c[1] === 'ads_data_redaction');
+    expect(redaction?.[2]).toBe(true);
+  });
+
+  test('accept-all fires a granted update', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+
+    const entries = await readDataLayer(page);
+    const updates = findConsentCalls(entries, 'update');
+    expect(updates.length).toBeGreaterThanOrEqual(1);
+
+    const last = updates[updates.length - 1];
+    expect(last).toEqual({
+      ad_storage: 'granted',
+      ad_user_data: 'granted',
+      ad_personalization: 'granted',
+      analytics_storage: 'granted',
+    });
+  });
+
+  test('reject-all fires a denied update', async ({ page }) => {
+    await page.locator('[data-cc=reject-all]').click();
+
+    const entries = await readDataLayer(page);
+    const updates = findConsentCalls(entries, 'update');
+    const last = updates[updates.length - 1];
+    expect(last).toEqual({
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'denied',
+    });
+  });
+
+  test('partial consent via modal grants analytics only', async ({ page }) => {
+    await page.locator('[data-cc=manage]').click();
+    await page.locator('label.cc-toggle:has([data-cc-category=analytics])').click();
+    await page.locator('[data-cc=save-preferences]').click();
+
+    const entries = await readDataLayer(page);
+    const updates = findConsentCalls(entries, 'update');
+    const last = updates[updates.length - 1];
+    expect(last).toEqual({
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted',
+    });
+  });
+
+  test('existing consent triggers update on reload', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+    await page.reload();
+
+    const entries = await readDataLayer(page);
+    const updates = findConsentCalls(entries, 'update');
+    expect(updates.length).toBeGreaterThanOrEqual(1);
+    expect(updates[updates.length - 1]).toMatchObject({
+      analytics_storage: 'granted',
+      ad_storage: 'granted',
+    });
+  });
+});

--- a/playground/e2e/recipes.spec.ts
+++ b/playground/e2e/recipes.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import { clearConsent } from './helpers';
+
+test.describe('Recipe snippets (GA4 / GTM / Meta Pixel)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/recipes');
+    await clearConsent(page);
+    await page.reload();
+  });
+
+  test('every recipe stays inert before consent', async ({ page }) => {
+    await expect(page.locator('#cc-banner')).toHaveClass(/cc-visible/);
+
+    await expect(page.locator('#recipe-ga4-marker')).toHaveAttribute('data-loaded', 'false');
+    await expect(page.locator('#recipe-ga4-inline-marker')).toHaveAttribute('data-loaded', 'false');
+    await expect(page.locator('#recipe-gtm-marker')).toHaveAttribute('data-loaded', 'false');
+    await expect(page.locator('#recipe-metapixel-marker')).toHaveAttribute('data-loaded', 'false');
+    await expect(page.locator('#recipe-metapixel-inline-marker')).toHaveAttribute('data-loaded', 'false');
+
+    expect(await page.evaluate(() => (window as any).__ccRecipeGA4Loaded)).toBeUndefined();
+    expect(await page.evaluate(() => (window as any).__ccRecipeGA4InlineLoaded)).toBeUndefined();
+    expect(await page.evaluate(() => (window as any).__ccRecipeGTMLoaded)).toBeUndefined();
+    expect(await page.evaluate(() => (window as any).__ccRecipeMetaPixelLoaded)).toBeUndefined();
+    expect(await page.evaluate(() => (window as any).__ccRecipeMetaPixelInlineLoaded)).toBeUndefined();
+  });
+
+  test('analytics-only consent loads GA4 and GTM, leaves Meta Pixel blocked', async ({ page }) => {
+    await page.locator('[data-cc=manage]').click();
+    await page.locator('label.cc-toggle:has([data-cc-category=analytics])').click();
+    await page.locator('[data-cc=save-preferences]').click();
+
+    await expect(page.locator('#recipe-ga4-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#recipe-ga4-inline-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#recipe-gtm-marker')).toHaveAttribute('data-loaded', 'true');
+
+    await expect(page.locator('#recipe-metapixel-marker')).toHaveAttribute('data-loaded', 'false');
+    await expect(page.locator('#recipe-metapixel-inline-marker')).toHaveAttribute('data-loaded', 'false');
+    expect(await page.evaluate(() => (window as any).__ccRecipeMetaPixelLoaded)).toBeUndefined();
+  });
+
+  test('accept-all fires every recipe', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+
+    await expect(page.locator('#recipe-ga4-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#recipe-ga4-inline-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#recipe-gtm-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#recipe-metapixel-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#recipe-metapixel-inline-marker')).toHaveAttribute('data-loaded', 'true');
+
+    expect(await page.evaluate(() => (window as any).__ccRecipeGA4Loaded)).toBe(true);
+    expect(await page.evaluate(() => (window as any).__ccRecipeGTMLoaded)).toBe(true);
+    expect(await page.evaluate(() => (window as any).__ccRecipeMetaPixelLoaded)).toBe(true);
+
+    // Inline Meta Pixel stub should have queued the init+PageView calls.
+    const fbqQueue = await page.evaluate(() => (window as any).fbq?.q?.map((a: any) => Array.from(a)));
+    expect(fbqQueue).toEqual([
+      ['init', '000000000000000'],
+      ['track', 'PageView'],
+    ]);
+  });
+
+  test('reject-all keeps everything blocked', async ({ page }) => {
+    await page.locator('[data-cc=reject-all]').click();
+
+    await expect(page.locator('#recipe-ga4-marker')).toHaveAttribute('data-loaded', 'false');
+    await expect(page.locator('#recipe-gtm-marker')).toHaveAttribute('data-loaded', 'false');
+    await expect(page.locator('#recipe-metapixel-marker')).toHaveAttribute('data-loaded', 'false');
+
+    expect(await page.evaluate(() => (window as any).__ccRecipeGA4Loaded)).toBeUndefined();
+    expect(await page.evaluate(() => (window as any).__ccRecipeGTMLoaded)).toBeUndefined();
+    expect(await page.evaluate(() => (window as any).__ccRecipeMetaPixelLoaded)).toBeUndefined();
+  });
+});

--- a/playground/e2e/revocation.spec.ts
+++ b/playground/e2e/revocation.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { clearConsent } from './helpers';
+
+test.describe('Revocation of a previously-granted category', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/scripts');
+    await clearConsent(page);
+    await page.reload();
+  });
+
+  test('activated script tag remains on revoke; fresh load stays inert', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+
+    await expect(page.locator('#inline-marker')).toHaveAttribute('data-loaded', 'true');
+    expect(await page.evaluate(() => (window as any).__ccInlineLoaded)).toBe(true);
+
+    const activatedAnalytics = page.locator(
+      'script[data-cc-activated="true"][data-cc-category="analytics"]',
+    );
+    const activatedCountBefore = await activatedAnalytics.count();
+    expect(activatedCountBefore).toBeGreaterThan(0);
+
+    await page.evaluate(() => window.astroConsent?.showPreferences());
+    await page.locator('label.cc-toggle:has([data-cc-category=analytics])').click();
+    await page.locator('[data-cc=save-preferences]').click();
+
+    const stateAfterRevoke = await page.evaluate(() => window.astroConsent?.get());
+    expect(stateAfterRevoke?.categories.analytics).toBe(false);
+
+    await expect(activatedAnalytics).toHaveCount(activatedCountBefore);
+    expect(await page.evaluate(() => (window as any).__ccInlineLoaded)).toBe(true);
+
+    await page.reload();
+
+    await expect(page.locator('#cc-banner')).not.toHaveClass(/cc-visible/);
+
+    expect(await page.evaluate(() => (window as any).__ccInlineLoaded)).toBeUndefined();
+    await expect(page.locator('#inline-marker')).toHaveAttribute('data-loaded', 'false');
+
+    await expect(
+      page.locator('script[type="text/plain"][data-cc-category="analytics"]'),
+    ).toHaveCount(2);
+    await expect(
+      page.locator('script[data-cc-activated="true"][data-cc-category="analytics"]'),
+    ).toHaveCount(0);
+  });
+});

--- a/playground/e2e/script-blocking.spec.ts
+++ b/playground/e2e/script-blocking.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { clearConsent } from './helpers';
+
+test.describe('Declarative script blocking', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/scripts');
+    await clearConsent(page);
+    await page.reload();
+  });
+
+  test('blocked scripts stay inert before consent', async ({ page }) => {
+    // Banner is still up — no category has been granted yet.
+    await expect(page.locator('#cc-banner')).toHaveClass(/cc-visible/);
+
+    expect(await page.evaluate(() => (window as any).__ccInlineLoaded)).toBeUndefined();
+    expect(await page.evaluate(() => (window as any).__ccExternalLoaded)).toBeUndefined();
+    expect(await page.evaluate(() => (window as any).__ccMarketingLoaded)).toBeUndefined();
+
+    await expect(page.locator('#inline-marker')).toHaveAttribute('data-loaded', 'false');
+    await expect(page.locator('#blocked-iframe')).not.toHaveAttribute('src', /.+/);
+  });
+
+  test('accept-all activates every blocked resource', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+
+    await expect(page.locator('#inline-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#ext-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#marketing-marker')).toHaveAttribute('data-loaded', 'true');
+
+    expect(await page.evaluate(() => (window as any).__ccInlineLoaded)).toBe(true);
+    expect(await page.evaluate(() => (window as any).__ccExternalLoaded)).toBe(true);
+    expect(await page.evaluate(() => (window as any).__ccMarketingLoaded)).toBe(true);
+
+    await expect(page.locator('#blocked-iframe')).toHaveAttribute('src', '/iframe-body.html');
+    await expect(page.locator('#blocked-iframe')).toHaveAttribute('data-cc-activated', 'true');
+  });
+
+  test('rejected category stays blocked', async ({ page }) => {
+    // Accept analytics only via the modal. Marketing should remain blocked.
+    await page.locator('[data-cc=manage]').click();
+    await page.locator('label.cc-toggle:has([data-cc-category=analytics])').click();
+    await page.locator('[data-cc=save-preferences]').click();
+
+    await expect(page.locator('#inline-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#marketing-marker')).toHaveAttribute('data-loaded', 'false');
+
+    expect(await page.evaluate(() => (window as any).__ccMarketingLoaded)).toBeUndefined();
+
+    // Iframe src must remain empty — marketing was denied.
+    const iframeSrc = await page.locator('#blocked-iframe').getAttribute('src');
+    expect(iframeSrc ?? '').toBe('');
+  });
+
+  test('existing consent activates scripts on reload', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+    await page.reload();
+
+    // No banner, activation happens via the initial CONSENT event on init.
+    await expect(page.locator('#inline-marker')).toHaveAttribute('data-loaded', 'true');
+    await expect(page.locator('#blocked-iframe')).toHaveAttribute('src', '/iframe-body.html');
+  });
+
+  test('MutationObserver activates dynamically-inserted scripts', async ({ page }) => {
+    await page.locator('[data-cc=accept-all]').click();
+
+    await expect(page.locator('#dynamic-marker')).toHaveAttribute('data-loaded', 'false');
+
+    await page.locator('#btn-insert').click();
+
+    await expect(page.locator('#dynamic-marker')).toHaveAttribute('data-loaded', 'true');
+    expect(await page.evaluate(() => (window as any).__ccDynamicLoaded)).toBe(true);
+  });
+
+  test('dynamically-inserted script stays blocked when category is denied', async ({ page }) => {
+    await page.locator('[data-cc=reject-all]').click();
+
+    await page.locator('#btn-insert').click();
+
+    // Give the observer a tick — the placeholder is added but must not run.
+    await page.waitForTimeout(100);
+
+    await expect(page.locator('#dynamic-marker')).toHaveAttribute('data-loaded', 'false');
+    expect(await page.evaluate(() => (window as any).__ccDynamicLoaded)).toBeUndefined();
+  });
+});

--- a/playground/public/iframe-body.html
+++ b/playground/public/iframe-body.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>Marketing embed</title>
+<body style="font: 14px system-ui; padding: 0.5rem">Marketing embed loaded.</body>

--- a/playground/public/recipes-ga4.js
+++ b/playground/public/recipes-ga4.js
@@ -1,0 +1,4 @@
+// Stand-in for gtag.js. Flips a marker so e2e tests can assert the external
+// GA4 script path unblocked correctly.
+window.__ccRecipeGA4Loaded = true;
+document.getElementById('recipe-ga4-marker')?.setAttribute('data-loaded', 'true');

--- a/playground/public/recipes-gtm.js
+++ b/playground/public/recipes-gtm.js
@@ -1,0 +1,3 @@
+// Stand-in for gtm.js — the script the inline GTM IIFE would normally fetch.
+window.__ccRecipeGTMLoaded = true;
+document.getElementById('recipe-gtm-marker')?.setAttribute('data-loaded', 'true');

--- a/playground/public/recipes-metapixel.js
+++ b/playground/public/recipes-metapixel.js
@@ -1,0 +1,4 @@
+// Stand-in for fbevents.js. Flips a marker so e2e tests can assert the
+// Meta Pixel script path unblocked correctly.
+window.__ccRecipeMetaPixelLoaded = true;
+document.getElementById('recipe-metapixel-marker')?.setAttribute('data-loaded', 'true');

--- a/playground/public/tracker-component.js
+++ b/playground/public/tracker-component.js
@@ -1,0 +1,3 @@
+// Stand-in tracker loaded via the ConsentScript component's `src` prop.
+window.__ccComponentExternalLoaded = true;
+document.getElementById('c-ext-marker')?.setAttribute('data-loaded', 'true');

--- a/playground/public/tracker.js
+++ b/playground/public/tracker.js
@@ -1,0 +1,4 @@
+// Stand-in for a third-party tracker loaded via `data-cc-src`. Serves as a
+// signal from e2e tests that the external script path unblocked correctly.
+window.__ccExternalLoaded = true;
+document.getElementById('ext-marker')?.setAttribute('data-loaded', 'true');

--- a/playground/src/layouts/Layout.astro
+++ b/playground/src/layouts/Layout.astro
@@ -74,6 +74,7 @@ const { title } = Astro.props;
       <a href="/about">About</a>
       <a href="/scripts">Scripts</a>
       <a href="/gcm">GCM</a>
+      <a href="/recipes">Recipes</a>
     </nav>
     <slot />
   </body>

--- a/playground/src/layouts/Layout.astro
+++ b/playground/src/layouts/Layout.astro
@@ -73,6 +73,7 @@ const { title } = Astro.props;
       <a href="/">Home</a>
       <a href="/about">About</a>
       <a href="/scripts">Scripts</a>
+      <a href="/gcm">GCM</a>
     </nav>
     <slot />
   </body>

--- a/playground/src/layouts/Layout.astro
+++ b/playground/src/layouts/Layout.astro
@@ -72,6 +72,7 @@ const { title } = Astro.props;
     <nav>
       <a href="/">Home</a>
       <a href="/about">About</a>
+      <a href="/scripts">Scripts</a>
     </nav>
     <slot />
   </body>

--- a/playground/src/pages/component.astro
+++ b/playground/src/pages/component.astro
@@ -1,0 +1,33 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { ConsentScript } from '@zdenekkurecka/astro-consent/components';
+---
+
+<Layout title="ConsentScript component">
+  <h1>ConsentScript component</h1>
+  <p>
+    Same gating as <code>/scripts</code>, but authored via the Astro component
+    instead of raw <code>type="text/plain"</code> markup.
+  </p>
+
+  <h2>Markers</h2>
+  <ul>
+    <li>Inline analytics: <span id="c-inline-marker" data-loaded="false">not loaded</span></li>
+    <li>External analytics: <span id="c-ext-marker" data-loaded="false">not loaded</span></li>
+    <li>Marketing inline (async attr): <span id="c-marketing-marker" data-loaded="false">not loaded</span></li>
+  </ul>
+
+  <ConsentScript category="analytics">
+    {`window.__ccComponentInlineLoaded = true;
+    var el = document.getElementById('c-inline-marker');
+    if (el) { el.setAttribute('data-loaded', 'true'); el.textContent = 'loaded'; }`}
+  </ConsentScript>
+
+  <ConsentScript category="analytics" src="/tracker-component.js" />
+
+  <ConsentScript category="marketing" async>
+    {`window.__ccComponentMarketingLoaded = true;
+    var el = document.getElementById('c-marketing-marker');
+    if (el) { el.setAttribute('data-loaded', 'true'); el.textContent = 'loaded'; }`}
+  </ConsentScript>
+</Layout>

--- a/playground/src/pages/gcm.astro
+++ b/playground/src/pages/gcm.astro
@@ -1,0 +1,46 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Google Consent Mode v2">
+  <h1>Google Consent Mode v2</h1>
+  <p>
+    The <code>googleConsentMode</code> config emits a
+    <code>gtag('consent', 'default', …)</code> call inline at the top of
+    <code>&lt;head&gt;</code>, then bridges
+    <code>astro-consent:consent</code> / <code>astro-consent:change</code>
+    into <code>gtag('consent', 'update', …)</code>.
+  </p>
+
+  <p>
+    The test hooks below instrument <code>window.dataLayer</code> so Playwright
+    can assert the correct default + update sequence without pulling in the
+    real GTM script.
+  </p>
+
+  <pre id="dl-dump">dataLayer will appear here…</pre>
+
+  <script is:inline>
+    // Render current dataLayer contents on load + whenever consent events fire.
+    // Using `is:inline` so the dump survives view transitions.
+    function renderDataLayer() {
+      const el = document.getElementById('dl-dump');
+      if (!el) return;
+      try {
+        const serialized = (window.dataLayer || []).map((entry) => {
+          // `arguments`-shaped entries (from gtag(...)) are array-like.
+          if (entry && typeof entry === 'object' && typeof entry.length === 'number') {
+            return Array.from(entry);
+          }
+          return entry;
+        });
+        el.textContent = JSON.stringify(serialized, null, 2);
+      } catch (err) {
+        el.textContent = 'failed to render dataLayer: ' + err;
+      }
+    }
+    document.addEventListener('astro:page-load', renderDataLayer);
+    document.addEventListener('astro-consent:consent', renderDataLayer);
+    document.addEventListener('astro-consent:change', renderDataLayer);
+  </script>
+</Layout>

--- a/playground/src/pages/gcm.astro
+++ b/playground/src/pages/gcm.astro
@@ -3,6 +3,27 @@ import Layout from '../layouts/Layout.astro';
 ---
 
 <Layout title="Google Consent Mode v2">
+  <!--
+    Real gtag.js load with a fake-but-format-valid Measurement ID so /g/collect
+    and ads/ga-audiences requests actually attempt to fire in the browser
+    Network tab for manual GCM verification. Google rejects the unknown ID
+    server-side, but the client-side request still happens — which is exactly
+    what the PR69 manual test item checks for.
+  -->
+  <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-PLAYGRNDXX"></script>
+  <script is:inline>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-PLAYGRNDXX');
+    // Google Ads tag: fake AW-* ID so gtag.js attempts the ads/ga-audiences
+    // remarketing ping once ad_storage is granted. GA4's own `/g/collect`
+    // does not fire ads/ga-audiences unless the property is linked to Google
+    // Ads server-side, which a fake G-* ID can't simulate — the AW tag is the
+    // reliable client-side trigger.
+    gtag('config', 'AW-1234567890');
+  </script>
+
   <h1>Google Consent Mode v2</h1>
   <p>
     The <code>googleConsentMode</code> config emits a
@@ -16,6 +37,13 @@ import Layout from '../layouts/Layout.astro';
     The test hooks below instrument <code>window.dataLayer</code> so Playwright
     can assert the correct default + update sequence without pulling in the
     real GTM script.
+  </p>
+
+  <p>
+    <button type="button" id="fire-test-event">Fire test event</button>
+    — sends <code>gtag('event', 'manual_test')</code>, useful for triggering a
+    fresh <code>/g/collect</code> hit after accepting consent (the initial
+    pageview is usually already cookieless-pinged past <code>wait_for_update</code>).
   </p>
 
   <pre id="dl-dump">dataLayer will appear here…</pre>
@@ -42,5 +70,13 @@ import Layout from '../layouts/Layout.astro';
     document.addEventListener('astro:page-load', renderDataLayer);
     document.addEventListener('astro-consent:consent', renderDataLayer);
     document.addEventListener('astro-consent:change', renderDataLayer);
+
+    document.addEventListener('click', (e) => {
+      const target = e.target;
+      if (target && target.id === 'fire-test-event' && typeof window.gtag === 'function') {
+        window.gtag('event', 'manual_test', { source: 'playground' });
+        renderDataLayer();
+      }
+    });
   </script>
 </Layout>

--- a/playground/src/pages/recipes.astro
+++ b/playground/src/pages/recipes.astro
@@ -1,0 +1,55 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { ConsentScript } from '@zdenekkurecka/astro-consent/components';
+---
+
+<Layout title="Recipes">
+  <h1>Recipes (GA4, GTM, Meta Pixel)</h1>
+  <p>
+    Verifies the wiring from <code>docs/recipes/</code> using stub scripts so
+    no real third-party network calls happen. Each recipe uses the same
+    <code>&lt;ConsentScript&gt;</code> component documented in the main README.
+  </p>
+
+  <h2>Markers</h2>
+  <ul>
+    <li>GA4 external: <span id="recipe-ga4-marker" data-loaded="false">not loaded</span></li>
+    <li>GA4 inline (<code>gtag('config', …)</code>): <span id="recipe-ga4-inline-marker" data-loaded="false">not loaded</span></li>
+    <li>GTM loader (inline IIFE → external stub): <span id="recipe-gtm-marker" data-loaded="false">not loaded</span></li>
+    <li>Meta Pixel external: <span id="recipe-metapixel-marker" data-loaded="false">not loaded</span></li>
+    <li>Meta Pixel inline (<code>fbq('init', …)</code>): <span id="recipe-metapixel-inline-marker" data-loaded="false">not loaded</span></li>
+  </ul>
+
+  <!-- GA4 recipe: analytics category. External loader + inline config. -->
+  <ConsentScript category="analytics" src="/recipes-ga4.js" async />
+  <ConsentScript category="analytics">
+    {`window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-RECIPE-STUB');
+    window.__ccRecipeGA4InlineLoaded = true;
+    var el = document.getElementById('recipe-ga4-inline-marker');
+    if (el) { el.setAttribute('data-loaded', 'true'); el.textContent = 'loaded'; }`}
+  </ConsentScript>
+
+  <!-- GTM recipe: analytics category (tags inside GTM would read GCM signals). -->
+  <ConsentScript category="analytics">
+    {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;
+    j.src='/recipes-gtm.js';
+    f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-RECIPE-STUB');`}
+  </ConsentScript>
+
+  <!-- Meta Pixel recipe: marketing category. External loader + inline init. -->
+  <ConsentScript category="marketing" src="/recipes-metapixel.js" />
+  <ConsentScript category="marketing">
+    {`window.fbq = window.fbq || function(){ (window.fbq.q = window.fbq.q || []).push(arguments); };
+    window.fbq('init', '000000000000000');
+    window.fbq('track', 'PageView');
+    window.__ccRecipeMetaPixelInlineLoaded = true;
+    var el = document.getElementById('recipe-metapixel-inline-marker');
+    if (el) { el.setAttribute('data-loaded', 'true'); el.textContent = 'loaded'; }`}
+  </ConsentScript>
+</Layout>

--- a/playground/src/pages/scripts.astro
+++ b/playground/src/pages/scripts.astro
@@ -1,0 +1,73 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Declarative script blocking">
+  <h1>Declarative script blocking</h1>
+  <p>
+    Demonstrates <code>data-cc-category</code> gating. Scripts here are
+    declared with <code>type="text/plain"</code> so the browser treats them
+    as inert data islands until consent is granted.
+  </p>
+
+  <h2>Markers</h2>
+  <ul>
+    <li>Inline analytics: <span id="inline-marker" data-loaded="false">not loaded</span></li>
+    <li>External analytics: <span id="ext-marker" data-loaded="false">not loaded</span></li>
+    <li>Marketing inline: <span id="marketing-marker" data-loaded="false">not loaded</span></li>
+    <li>Dynamic analytics: <span id="dynamic-marker" data-loaded="false">not loaded</span></li>
+  </ul>
+
+  <iframe
+    id="blocked-iframe"
+    data-cc-category="marketing"
+    data-cc-src="/iframe-body.html"
+    width="320"
+    height="80"
+    title="Blocked marketing iframe"
+  ></iframe>
+
+  <button id="btn-insert" type="button">Insert blocked script dynamically</button>
+
+  <!--
+    is:inline keeps Astro from processing / bundling these tags — we need the
+    raw type="text/plain" placeholder markup to survive to the browser.
+  -->
+  <script is:inline type="text/plain" data-cc-category="analytics">
+    window.__ccInlineLoaded = true;
+    var el = document.getElementById('inline-marker');
+    if (el) { el.setAttribute('data-loaded', 'true'); el.textContent = 'loaded'; }
+  </script>
+
+  <script
+    is:inline
+    type="text/plain"
+    data-cc-category="analytics"
+    data-cc-src="/tracker.js"
+  ></script>
+
+  <script is:inline type="text/plain" data-cc-category="marketing">
+    window.__ccMarketingLoaded = true;
+    var el = document.getElementById('marketing-marker');
+    if (el) { el.setAttribute('data-loaded', 'true'); el.textContent = 'loaded'; }
+  </script>
+
+  <script>
+    document.addEventListener('astro:page-load', () => {
+      document.getElementById('btn-insert')?.addEventListener('click', () => {
+        // Build the placeholder in the same shape as the static ones above.
+        // The MutationObserver inside the integration should pick it up and
+        // unblock it if the `analytics` category is currently granted.
+        const s = document.createElement('script');
+        s.setAttribute('type', 'text/plain');
+        s.setAttribute('data-cc-category', 'analytics');
+        s.textContent = [
+          'window.__ccDynamicLoaded = true;',
+          "var el = document.getElementById('dynamic-marker');",
+          "if (el) { el.setAttribute('data-loaded', 'true'); el.textContent = 'loaded'; }",
+        ].join('\n');
+        document.body.appendChild(s);
+      });
+    });
+  </script>
+</Layout>


### PR DESCRIPTION
## Summary

Release **v0.3.0** — four new features and a runtime fix. Once this PR merges, the Changesets pipeline opens a "Version Packages" PR that bumps `@zdenekkurecka/astro-consent` from `0.2.2` to `0.3.0` and publishes to npm on merge.

## What's shipping

**Minor — new features**

- **`<ConsentScript>` Astro component** for category-gated scripts (#21) — named-prop wrapper over the `type="text/plain"` + `data-cc-category` markup, passes through `async` / `defer` / `nonce` / `integrity` / `crossorigin`.
- **Declarative script blocking** via `data-cc-category` / `data-cc-src` — gate external scripts, inline bodies, and iframes with markup; covers both initial scan and a `MutationObserver` for late-inserted elements.
- **Generic `ConsentConfig<K>`** (#32) — `ConsentConfig`, `ConsentState`, `ConsentText` take an optional `K extends string` generic; typos in category keys become compile-time errors. Defaults to `string`, so existing code keeps compiling.
- **Google Consent Mode v2** (#19) — opt-in `googleConsentMode` config: injects the default-denied snippet, bridges `astro-consent:consent` / `:change` into `gtag('consent', 'update', …)` (AND semantics across categories), forwards `adsDataRedaction` / `urlPassthrough`, supports per-region defaults.
- **Typed events + runtime API** via `ConsentKeys` augmentation (#70, #71) — drop a project-level `.d.ts` to narrow `e.detail.categories` and `window.astroConsent.set(…)` to declared keys. Re-exports `ConsentEvent`, `ConsentKeys`, `ResolvedConsentKeys`, `CONSENT_EVENT`, `CHANGE_EVENT` from the package entry.

**Patch — fixes (v0.3.0 review)**

- Correct `astro-consent:change` vs `astro-consent:consent` dispatch on re-accept / re-reject from `show()` / `showPreferences()`.
- Preserve CSP nonce on declarative script activation (use `.nonce` IDL property instead of `getAttribute`; CSP L3 hides the content attribute post-parse).

**Docs**

- GA4, GTM, and Meta Pixel recipes (#26).

## Test plan

- [ ] CI green on this PR (publint + playground build + Playwright matrix)
- [ ] After merge: verify `publish.yml` opens the "Version Packages" PR bumping to `0.3.0` and consuming all 6 changesets
- [ ] Merge the Version PR and confirm:
  - [ ] `@zdenekkurecka/astro-consent@0.3.0` on npm with provenance attestation
  - [ ] Tag `astro-consent-v0.3.0` and matching GitHub Release exist
  - [ ] `CHANGELOG.md` on main contains the 0.3.0 section
- [ ] Fast-forward `dev` to `main` so the version bump lands on dev

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
