### PR TITLE
ci(release): retry npm registry read before skipping reconcile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -129,7 +129,23 @@ jobs:
 
             # Only reconcile versions actually on npm. Avoids creating tags
             # for a version bump whose publish step failed.
-            if ! npm view "${name}@${version}" version >/dev/null 2>&1; then
+            #
+            # `changeset publish` reports success as soon as npm accepts the
+            # write, but the public registry read path has propagation lag
+            # (observed ~5-30s). Retry before declaring it unpublished so we
+            # don't flakily skip tag + release creation right after a fresh
+            # publish. A truly failed publish will still miss every attempt
+            # and fall through to `continue`, preserving the original guard.
+            published=""
+            for attempt in 1 2 3 4 5 6; do
+              if npm view "${name}@${version}" version >/dev/null 2>&1; then
+                published=1
+                break
+              fi
+              echo "npm view ${name}@${version} not visible yet (attempt ${attempt}/6) — retrying in 10s"
+              sleep 10
+            done
+            if [ -z "$published" ]; then
               echo "Skip ${name}@${version}: not published to npm yet"
               continue
             fi


### PR DESCRIPTION
## Summary

Fix a race in `publish.yml` that caused the v0.3.0 release to publish to npm successfully but leave main without the `astro-consent-v0.3.0` tag and without a GitHub Release.

## Root cause

The "Reconcile tags and GitHub Releases" step guards tag/release creation with:

```bash
if ! npm view "${name}@${version}" version >/dev/null 2>&1; then
  echo "Skip ${name}@${version}: not published to npm yet"
  continue
fi
```

Guard intent: don't create a tag if the publish step failed silently (e.g. OIDC token rejected after a dry-run).

Actual behaviour on v0.3.0: `changeset publish` succeeded at `10:22:31.578`, the reconcile step ran `npm view` at `10:22:32.085` — **~500ms later**. npm accepts writes synchronously but the public read path lags 5–30s for fresh versions. The guard returned non-zero, the step logged `Skip @zdenekkurecka/astro-consent@0.3.0: not published to npm yet`, and no tag or release was created. The release had to be reconciled manually via `workflow_dispatch` rerun.

The guard was introduced in #67 (`ci/harden-publish`) and must have gotten lucky on v0.2.1 / v0.2.2 releases.

## Fix

Replace the one-shot `npm view` check with a retry loop — 6 attempts at 10s intervals (60s max) before declaring the version unpublished:

```bash
published=""
for attempt in 1 2 3 4 5 6; do
  if npm view "${name}@${version}" version >/dev/null 2>&1; then
    published=1
    break
  fi
  echo "npm view ${name}@${version} not visible yet (attempt ${attempt}/6) — retrying in 10s"
  sleep 10
done
if [ -z "$published" ]; then
  echo "Skip ${name}@${version}: not published to npm yet"
  continue
fi
```

The original guard semantics are preserved for genuinely failed publishes — they miss every attempt and fall through to `continue`. The only behavioural change is tolerance for registry propagation lag.

## Test plan

- [ ] CI green on this PR
- [ ] Next release (patch or otherwise) produces tag + GitHub Release in a single workflow run with no manual rerun

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
