### PR TITLE
feat(ui): four banner layout variants — bar, box, cloud, popup

### DIFF
--- a/.changeset/banner-layouts.md
+++ b/.changeset/banner-layouts.md
@@ -1,0 +1,32 @@
+---
+'@zdenekkurecka/astro-consent': minor
+---
+
+Four banner layout variants — `bar`, `box`, `cloud`, `popup` — with configurable position. Default remains `bar` + `bottom`, so existing installations don't shift visually after upgrade.
+
+```ts
+cookieConsent({
+  version: 1,
+  categories: { /* ... */ },
+  ui: {
+    banner: {
+      layout: 'box',          // 'bar' | 'box' | 'cloud' | 'popup'
+      position: 'bottom-right',
+      scrim: false,           // cloud-only passthrough; popup always on, bar/box always off
+    },
+  },
+});
+```
+
+Position validity per layout — invalid combinations fall back to the layout's default and emit a `console.warn` in dev:
+
+| Layout  | Valid positions                                            |
+| ------- | ---------------------------------------------------------- |
+| `bar`   | `top`, `bottom`                                            |
+| `box`   | `top-left`, `top-right`, `bottom-left`, `bottom-right`     |
+| `cloud` | `top`, `bottom`                                            |
+| `popup` | `center`                                                   |
+
+New CSS custom properties: `--cc-banner-max-width`, `--cc-box-width`, `--cc-popup-width`, `--cc-banner-offset`. All layouts are driven by `data-cc-layout` / `data-cc-position` / `data-cc-scrim` attributes on the banner root, so consumers can override layouts with their own CSS without forking the integration.
+
+Closes #39.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   - [Recipes (GA4, GTM, Meta Pixel)](#recipes-ga4-gtm-meta-pixel)
   - [Re-prompt users after changing categories](#re-prompt-users-after-changing-categories)
   - [Customise banner & modal text (and localize it)](#customise-banner--modal-text-and-localize-it)
+  - [Choose a banner layout](#choose-a-banner-layout)
   - [Theme the UI](#theme-the-ui)
   - [Use with a strict Content Security Policy](#use-with-a-strict-content-security-policy)
   - [Debug mode](#debug-mode)
@@ -211,6 +212,41 @@ interface ConsentConfig {
    * @default false
    */
   debug?: boolean;
+
+  /** Visual / placement configuration for the banner and modal. */
+  ui?: {
+    /**
+     * Forces the consent UI into `"light"` / `"dark"` by setting
+     * `data-cc-theme` on `:root`. `"auto"` (default) follows
+     * `prefers-color-scheme`.
+     */
+    colorMode?: 'auto' | 'light' | 'dark';
+    /**
+     * Banner layout and placement. See
+     * [Choose a banner layout](#choose-a-banner-layout) for the visuals and
+     * valid position-per-layout combinations.
+     */
+    banner?: {
+      /** @default "bar" */
+      layout?: 'bar' | 'box' | 'cloud' | 'popup';
+      /** Defaults vary per layout — `bottom` for `bar`/`cloud`, `bottom-right` for `box`, `center` for `popup`. */
+      position?:
+        | 'top'
+        | 'bottom'
+        | 'top-left'
+        | 'top-right'
+        | 'bottom-left'
+        | 'bottom-right'
+        | 'center';
+      /**
+       * Dim the page behind the banner. Passthrough for `cloud`; forced on
+       * for `popup`; forced off for `bar` and `box`.
+       *
+       * @default false
+       */
+      scrim?: boolean;
+    };
+  };
 
   /**
    * Single-language text overrides for the banner and modal. Any field
@@ -727,6 +763,136 @@ to their initial — the card still paints, it just won't re-derive when only
 `--cc-primary` or `--cc-tone` is overridden. If you need to support legacy
 browsers, either override each token explicitly (using the defaults above as
 a starting point), or inline `color-mix()` at build time with PostCSS.
+
+### Choose a banner layout
+
+Four banner layouts ship out of the box. The default is `bar` + `bottom` — a
+full-width strip along the viewport edge, exactly what earlier versions of the
+integration rendered. Swap it via `ui.banner`:
+
+```ts
+cookieConsent({
+  version: 1,
+  categories: { /* ... */ },
+  ui: {
+    banner: {
+      layout: 'box',          // 'bar' | 'box' | 'cloud' | 'popup'
+      position: 'bottom-right',
+      scrim: false,           // cloud-only passthrough; popup always on, bar/box always off
+    },
+  },
+});
+```
+
+#### `bar` — full-width strip (default)
+
+```
+┌───────────────────────────────────┐
+│                                   │
+│          page content             │
+│                                   │
+├───────────────────────────────────┤
+│ 🍪  We use cookies…   [✓] [✗] [⚙] │
+└───────────────────────────────────┘
+```
+
+Edge-to-edge strip anchored to `bottom` (default) or `top`. Minimal visual
+disruption — the right default for content-heavy sites that just need a clear
+opt-in surface.
+
+#### `box` — corner card
+
+```
+┌───────────────────────────────────┐
+│                                   │
+│                                   │
+│          page content             │
+│                                   │
+│                     ┌────────────┐│
+│                     │ 🍪 We use  ││
+│                     │ cookies…   ││
+│                     │ [✓] [✗]    ││
+│                     │ [⚙]        ││
+│                     └────────────┘│
+└───────────────────────────────────┘
+```
+
+Compact card (≈ 420px) pinned to any corner. Buttons stack inside so the card
+stays narrow. Good for product UIs that want the consent out of the way.
+
+#### `cloud` — floating padded strip
+
+```
+┌───────────────────────────────────┐
+│                                   │
+│          page content             │
+│                                   │
+│  ╭─────────────────────────────╮  │
+│  │ 🍪 We use cookies…  [✓][✗]… │  │
+│  ╰─────────────────────────────╯  │
+└───────────────────────────────────┘
+```
+
+Rounded card with side margins, floating above the page. Optionally pair with
+`scrim: true` to dim the background without turning it into a modal.
+
+#### `popup` — centered modal
+
+```
+┌───────────────────────────────────┐
+│░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
+│░░░░░░░  ┌─────────────────┐  ░░░░ │
+│░░░░░░░  │ 🍪 We use       │  ░░░░ │
+│░░░░░░░  │ cookies…        │  ░░░░ │
+│░░░░░░░  │   [✓]   [✗]     │  ░░░░ │
+│░░░░░░░  │     [⚙]         │  ░░░░ │
+│░░░░░░░  └─────────────────┘  ░░░░ │
+│░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
+└───────────────────────────────────┘
+```
+
+Centered card with an always-on scrim. Demands an explicit choice — use when
+passive consent isn't legally sufficient. The scrim is click-inert: there's
+no dismiss-by-clicking-outside, because that would silently record a choice.
+
+#### Position validity per layout
+
+Invalid combinations fall back to the layout's default and emit a
+`console.warn` in dev so misconfiguration is loud.
+
+| Layout  | Valid positions                                            | Default          |
+| ------- | ---------------------------------------------------------- | ---------------- |
+| `bar`   | `top`, `bottom`                                            | `bottom`         |
+| `box`   | `top-left`, `top-right`, `bottom-left`, `bottom-right`     | `bottom-right`   |
+| `cloud` | `top`, `bottom`                                            | `bottom`         |
+| `popup` | `center`                                                   | `center`         |
+
+#### Layout-related CSS tokens
+
+Every layout honours the visual tokens above; a handful of extra knobs control
+width and viewport gutters. Override them on `:root` to fine-tune the frame
+without re-writing per-variant selectors.
+
+| Token | Default | Role |
+| --- | --- | --- |
+| `--cc-banner-max-width` | `72rem` | Content cap inside `bar` / `cloud`. Doesn't affect `box` / `popup`. |
+| `--cc-box-width` | `26rem` | Target width of the `box` variant. Caps against viewport width minus `--cc-banner-offset` gutters. |
+| `--cc-popup-width` | `30rem` | Target width of the `popup` variant. Caps the same way as `--cc-box-width`. |
+| `--cc-banner-offset` | `1rem` | Gap between the banner and viewport edges for `box` / `cloud` / `popup`. Also shrinks the responsive cap on width. |
+
+#### Styling hooks
+
+The banner renders a single element whose layout is selected via data
+attributes: `data-cc-layout` (`bar` / `box` / `cloud` / `popup`),
+`data-cc-position`, and `data-cc-scrim`. Target them directly if you want to
+override per-variant styling without forking the integration.
+
+```css
+/* Tighten the box variant on marketing pages only */
+.marketing .cc-banner[data-cc-layout='box'] {
+  --cc-box-width: 22rem;
+}
+```
 
 ### Use with a strict Content Security Policy
 

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -50,6 +50,15 @@
     0 24px 64px #0f172a26,
     0 4px 16px #0f172a1a;
   --cc-font-family: inherit;
+
+  /* ── Banner layout geometry ──
+   * Shared across `bar`, `box`, `cloud`, `popup` variants. Override these to
+   * tune widths or viewport gutters without re-writing per-variant selectors.
+   */
+  --cc-banner-max-width: 72rem;   /* bar / cloud content cap */
+  --cc-box-width: 26rem;          /* box variant target width (≈ 420px) */
+  --cc-popup-width: 30rem;        /* popup variant target width (≈ 480px) */
+  --cc-banner-offset: 1rem;       /* gap from viewport edges for box / cloud */
 }
 
 /* ── Dark mode defaults (prefers-color-scheme) ──────────────
@@ -105,11 +114,15 @@
 
 /* ── Banner ─────────────────────────────────────────────── */
 
+/*
+ * The banner is a single element whose layout (`bar`, `box`, `cloud`, `popup`)
+ * and position (`top`, `bottom`, `bottom-right`, …) are selected via data
+ * attributes set by `createBannerHTML()`. Base rules here cover the shared
+ * appearance — surface, typography, transition — and per-layout blocks below
+ * handle positioning, width, and edge treatment.
+ */
 .cc-banner {
   position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
   z-index: 9999;
   background:
     radial-gradient(120% 70% at 90% 0%, var(--cc-aura-1) 0%, transparent 55%),
@@ -117,11 +130,9 @@
     linear-gradient(180deg, var(--cc-surface-2), var(--cc-surface-3));
   backdrop-filter: blur(24px) saturate(1.2);
   -webkit-backdrop-filter: blur(24px) saturate(1.2);
-  border-top: 1px solid var(--cc-stroke-2);
   box-shadow: var(--cc-shadow-card);
   font-family: var(--cc-font-family);
   color: var(--cc-text);
-  transform: translateY(100%);
   opacity: 0;
   transition: transform 0.3s ease, opacity 0.3s ease;
   pointer-events: none;
@@ -129,13 +140,12 @@
 }
 
 .cc-banner.cc-visible {
-  transform: translateY(0);
   opacity: 1;
   pointer-events: auto;
 }
 
 .cc-banner-inner {
-  max-width: 72rem;
+  max-width: var(--cc-banner-max-width);
   margin: 0 auto;
   padding: 1rem 1.5rem;
   display: flex;
@@ -159,6 +169,135 @@
   gap: 0.5rem;
   flex-shrink: 0;
   flex-wrap: wrap;
+}
+
+/* ── Banner scrim ───────────────────────────────────────────
+ * Rendered only when `data-cc-scrim="true"` on the banner (popup always;
+ * cloud when `ui.banner.scrim: true`). Click-inert by design — consent
+ * requires an explicit choice, so clicking the scrim does nothing.
+ */
+.cc-banner-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  background-color: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.cc-banner-scrim.cc-visible {
+  opacity: 1;
+  /* Intentionally no pointer-events: auto — scrim is a visual dimmer only. */
+}
+
+/* ── Layout: bar ─── full-width strip, edge to edge ─── */
+.cc-banner[data-cc-layout='bar'] {
+  left: 0;
+  right: 0;
+}
+.cc-banner[data-cc-layout='bar'][data-cc-position='bottom'] {
+  bottom: 0;
+  border-top: 1px solid var(--cc-stroke-2);
+  transform: translateY(100%);
+}
+.cc-banner[data-cc-layout='bar'][data-cc-position='top'] {
+  top: 0;
+  border-bottom: 1px solid var(--cc-stroke-2);
+  transform: translateY(-100%);
+}
+.cc-banner[data-cc-layout='bar'].cc-visible {
+  transform: translateY(0);
+}
+
+/* ── Layout: box ─── compact corner card ─── */
+.cc-banner[data-cc-layout='box'] {
+  width: min(var(--cc-box-width), calc(100vw - var(--cc-banner-offset) * 2));
+  border: 1px solid var(--cc-stroke-2);
+  border-radius: var(--cc-radius);
+  overflow: hidden;
+  transform: translateY(24px);
+}
+.cc-banner[data-cc-layout='box'][data-cc-position='bottom-right'] {
+  bottom: var(--cc-banner-offset);
+  right: var(--cc-banner-offset);
+}
+.cc-banner[data-cc-layout='box'][data-cc-position='bottom-left'] {
+  bottom: var(--cc-banner-offset);
+  left: var(--cc-banner-offset);
+}
+.cc-banner[data-cc-layout='box'][data-cc-position='top-right'] {
+  top: var(--cc-banner-offset);
+  right: var(--cc-banner-offset);
+  transform: translateY(-24px);
+}
+.cc-banner[data-cc-layout='box'][data-cc-position='top-left'] {
+  top: var(--cc-banner-offset);
+  left: var(--cc-banner-offset);
+  transform: translateY(-24px);
+}
+.cc-banner[data-cc-layout='box'].cc-visible {
+  transform: translateY(0);
+}
+.cc-banner[data-cc-layout='box'] .cc-banner-inner {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 1rem;
+  padding: 1.25rem;
+}
+.cc-banner[data-cc-layout='box'] .cc-banner-actions {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+.cc-banner[data-cc-layout='box'] .cc-banner-actions > :nth-child(3) {
+  grid-column: 1 / -1;
+}
+
+/* ── Layout: cloud ─── floating padded strip ─── */
+.cc-banner[data-cc-layout='cloud'] {
+  left: var(--cc-banner-offset);
+  right: var(--cc-banner-offset);
+  border: 1px solid var(--cc-stroke-2);
+  border-radius: var(--cc-radius);
+  overflow: hidden;
+}
+.cc-banner[data-cc-layout='cloud'][data-cc-position='bottom'] {
+  bottom: var(--cc-banner-offset);
+  transform: translateY(calc(100% + var(--cc-banner-offset)));
+}
+.cc-banner[data-cc-layout='cloud'][data-cc-position='top'] {
+  top: var(--cc-banner-offset);
+  transform: translateY(calc(-100% - var(--cc-banner-offset)));
+}
+.cc-banner[data-cc-layout='cloud'].cc-visible {
+  transform: translateY(0);
+}
+
+/* ── Layout: popup ─── centered modal card ─── */
+.cc-banner[data-cc-layout='popup'] {
+  top: 50%;
+  left: 50%;
+  width: min(var(--cc-popup-width), calc(100vw - var(--cc-banner-offset) * 2));
+  max-height: calc(100vh - var(--cc-banner-offset) * 2);
+  overflow-y: auto;
+  border: 1px solid var(--cc-stroke-2);
+  border-radius: var(--cc-radius);
+  transform: translate(-50%, -50%) scale(0.96);
+}
+.cc-banner[data-cc-layout='popup'].cc-visible {
+  transform: translate(-50%, -50%) scale(1);
+}
+.cc-banner[data-cc-layout='popup'] .cc-banner-inner {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 1rem;
+  padding: 1.5rem;
+}
+.cc-banner[data-cc-layout='popup'] .cc-banner-actions {
+  justify-content: center;
 }
 
 /* ── Modal ──────────────────────────────────────────────── */

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -114,6 +114,53 @@ export interface CookiePolicyLink {
 /** Color mode for the consent UI. */
 export type ConsentColorMode = 'auto' | 'light' | 'dark';
 
+/**
+ * Banner layout variant.
+ *
+ * - `"bar"` — full-width strip anchored to the top or bottom (default).
+ * - `"box"` — compact card floating in a viewport corner.
+ * - `"cloud"` — padded floating card anchored to top or bottom, with margins.
+ * - `"popup"` — centered modal with a scrim; demands interaction.
+ */
+export type BannerLayout = 'bar' | 'box' | 'cloud' | 'popup';
+
+/** Banner position on the viewport. Not all positions are valid for all layouts. */
+export type BannerPosition =
+  | 'top'
+  | 'bottom'
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right'
+  | 'center';
+
+/**
+ * Banner layout + placement configuration.
+ *
+ * Position validity per layout:
+ * - `bar`   — `top`, `bottom` (default `bottom`)
+ * - `box`   — `top-left`, `top-right`, `bottom-left`, `bottom-right` (default `bottom-right`)
+ * - `cloud` — `top`, `bottom` (default `bottom`)
+ * - `popup` — `center` (only)
+ *
+ * Invalid combinations fall back to the layout's default and emit a
+ * `console.warn` in dev.
+ */
+export interface ConsentBannerConfig {
+  /** Layout variant. @default "bar" */
+  layout?: BannerLayout;
+  /** Viewport position. Defaults vary per layout — see above. */
+  position?: BannerPosition;
+  /**
+   * Render a dimming scrim behind the banner. Forced on for `popup` (the
+   * scrim is the layout's premise), forced off for `bar` and `box`, opt-in
+   * for `cloud`.
+   *
+   * @default false
+   */
+  scrim?: boolean;
+}
+
 /** Visual/UI-level configuration for the consent banner and modal. */
 export interface ConsentUIConfig {
   /**
@@ -127,6 +174,9 @@ export interface ConsentUIConfig {
    * @default "auto"
    */
   colorMode?: ConsentColorMode;
+
+  /** Banner layout + placement. Omit for the default bottom bar. */
+  banner?: ConsentBannerConfig;
 }
 
 /** Per-category label/description override used in `ConsentText.categories`. */

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -1,4 +1,6 @@
 import type {
+  BannerLayout,
+  BannerPosition,
   ConsentCategory,
   ConsentCategoryText,
   ConsentText,
@@ -148,6 +150,77 @@ const MODAL_ID = 'cc-modal';
 const MODAL_TITLE_ID = 'cc-modal-title';
 const OVERLAY_ID = 'cc-overlay';
 const BANNER_ID = 'cc-banner';
+const BANNER_SCRIM_ID = 'cc-banner-scrim';
+
+const VALID_LAYOUTS: readonly BannerLayout[] = ['bar', 'box', 'cloud', 'popup'];
+const VALID_POSITIONS_PER_LAYOUT: Record<BannerLayout, readonly BannerPosition[]> = {
+  bar: ['bottom', 'top'],
+  box: ['bottom-right', 'bottom-left', 'top-right', 'top-left'],
+  cloud: ['bottom', 'top'],
+  popup: ['center'],
+};
+const DEFAULT_POSITION_FOR: Record<BannerLayout, BannerPosition> = {
+  bar: 'bottom',
+  box: 'bottom-right',
+  cloud: 'bottom',
+  popup: 'center',
+};
+
+/**
+ * Resolved banner placement after applying defaults, validating the layout /
+ * position pairing, and normalizing the `scrim` flag (forced on for `popup`,
+ * off for `bar` / `box`, passthrough for `cloud`).
+ */
+export interface ResolvedBannerOptions {
+  layout: BannerLayout;
+  position: BannerPosition;
+  scrim: boolean;
+}
+
+/**
+ * Resolve banner layout / position / scrim from the merged config. Also
+ * honors `<html data-cc-test-layout>` and `<html data-cc-test-position>` so
+ * the playground harness (see `playground/e2e/helpers.ts`) can exercise
+ * variants via URL params without a rebuild.
+ *
+ * Invalid layout/position pairings fall back to the layout's default and
+ * emit a single `console.warn` so misconfiguration is loud in dev. Unknown
+ * layouts fall back to `bar`.
+ */
+export function resolveBannerOptions(
+  config: SerializableConsentConfig,
+): ResolvedBannerOptions {
+  const banner = config.ui?.banner ?? {};
+  const html = typeof document !== 'undefined' ? document.documentElement : null;
+  const harnessLayout = html?.getAttribute('data-cc-test-layout') as BannerLayout | null;
+  const harnessPosition = html?.getAttribute('data-cc-test-position') as BannerPosition | null;
+
+  let layout = (harnessLayout ?? banner.layout ?? 'bar') as BannerLayout;
+  if (!VALID_LAYOUTS.includes(layout)) {
+    console.warn(
+      `[astro-consent] Unknown banner layout "${layout}". Falling back to "bar".`,
+    );
+    layout = 'bar';
+  }
+
+  const requestedPosition = (harnessPosition ?? banner.position) as BannerPosition | undefined;
+  let position = requestedPosition ?? DEFAULT_POSITION_FOR[layout];
+  if (requestedPosition && !VALID_POSITIONS_PER_LAYOUT[layout].includes(requestedPosition)) {
+    console.warn(
+      `[astro-consent] Position "${requestedPosition}" is invalid for layout "${layout}". ` +
+        `Falling back to "${DEFAULT_POSITION_FOR[layout]}".`,
+    );
+    position = DEFAULT_POSITION_FOR[layout];
+  }
+
+  // Scrim: forced true for popup (the scrim is the layout's premise),
+  // forced false for bar/box, passthrough for cloud.
+  let scrim = banner.scrim ?? false;
+  if (layout === 'popup') scrim = true;
+  else if (layout === 'bar' || layout === 'box') scrim = false;
+
+  return { layout, position, scrim };
+}
 
 let previouslyFocused: HTMLElement | null = null;
 
@@ -183,10 +256,36 @@ function createPolicyLinkHTML(
   return `<a class="${className}" href="${escapeHtml(safeUrl)}" data-cc="policy-link">${escapeHtml(label)}</a>`;
 }
 
-function createBannerHTML(config: SerializableConsentConfig, text: ResolvedConsentText): string {
+function createBannerHTML(
+  config: SerializableConsentConfig,
+  text: ResolvedConsentText,
+  banner: ResolvedBannerOptions,
+): string {
   const policyLink = createPolicyLinkHTML(config.cookiePolicy, 'cc-policy-link');
+  // Popup gets role="dialog" + aria-modal so it's announced as modal UI; the
+  // other variants stay as a polite region.
+  const roleAttrs =
+    banner.layout === 'popup'
+      ? `role="dialog" aria-modal="true" aria-label="Cookie consent"`
+      : `role="region" aria-label="Cookie consent"`;
+  // Scrim element shares the banner's visibility class; positioned behind the
+  // banner via z-index. Rendered only when scrim is active so the DOM stays
+  // minimal for the default bar variant.
+  const scrimHTML = banner.scrim
+    ? `<div class="cc-banner-scrim" id="${BANNER_SCRIM_ID}" data-testid="cc-banner-scrim" aria-hidden="true"></div>`
+    : '';
   return `
-    <div class="cc-banner" id="${BANNER_ID}" data-testid="cc-banner" role="region" aria-label="Cookie consent" aria-hidden="true">
+    ${scrimHTML}
+    <div
+      class="cc-banner"
+      id="${BANNER_ID}"
+      data-testid="cc-banner"
+      data-cc-layout="${banner.layout}"
+      data-cc-position="${banner.position}"
+      data-cc-scrim="${banner.scrim ? 'true' : 'false'}"
+      ${roleAttrs}
+      aria-hidden="true"
+    >
       <div class="cc-banner-inner">
         <p class="cc-banner-text">
           ${escapeHtml(text.bannerText)}
@@ -300,9 +399,10 @@ function createModalHTML(config: SerializableConsentConfig, text: ResolvedConsen
 export function injectUI(config: SerializableConsentConfig, text: ResolvedConsentText): void {
   if (document.getElementById(CONTAINER_ID)) return;
 
+  const banner = resolveBannerOptions(config);
   const container = document.createElement('div');
   container.id = CONTAINER_ID;
-  container.innerHTML = createBannerHTML(config, text) + createModalHTML(config, text);
+  container.innerHTML = createBannerHTML(config, text, banner) + createModalHTML(config, text);
   document.body.appendChild(container);
 
   // Apply forced color mode (if any). "auto" / undefined leaves the
@@ -335,12 +435,16 @@ export function showBanner(): void {
   const el = document.getElementById(BANNER_ID);
   el?.classList.add('cc-visible');
   el?.setAttribute('aria-hidden', 'false');
+  const scrim = document.getElementById(BANNER_SCRIM_ID);
+  scrim?.classList.add('cc-visible');
 }
 
 export function hideBanner(): void {
   const el = document.getElementById(BANNER_ID);
   el?.classList.remove('cc-visible');
   el?.setAttribute('aria-hidden', 'true');
+  const scrim = document.getElementById(BANNER_SCRIM_ID);
+  scrim?.classList.remove('cc-visible');
 }
 
 /**

--- a/playground/src/pages/index.astro
+++ b/playground/src/pages/index.astro
@@ -3,6 +3,18 @@ import Layout from '../layouts/Layout.astro';
 ---
 
 <Layout title="Cookie Consent Playground">
+  <style>
+    /* Layout.astro gives .controls button a solid white/pointer style that
+     * hides the browser's default disabled treatment — reinstate a muted
+     * look so invalid positions for the current layout read as unavailable. */
+    .controls button:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .controls button:disabled:hover {
+      background: white;
+    }
+  </style>
   <h1>Cookie Consent Playground</h1>
   <p>
     This page demonstrates the <code>@zdenekkurecka/astro-consent</code> integration.
@@ -27,6 +39,31 @@ import Layout from '../layouts/Layout.astro';
     <button id="btn-get">Get State</button>
   </div>
 
+  <h2>Banner Layout</h2>
+  <p>
+    Live-swap the banner variant. Also drivable from the URL via
+    <code>?layout=box&amp;position=bottom-right&amp;scrim=true</code> —
+    page reloads pick up those params via the harness.
+  </p>
+  <div class="controls" data-cc-picker="layout">
+    <button data-val="bar">bar</button>
+    <button data-val="box">box</button>
+    <button data-val="cloud">cloud</button>
+    <button data-val="popup">popup</button>
+  </div>
+  <div class="controls" data-cc-picker="position">
+    <button data-val="top">top</button>
+    <button data-val="bottom">bottom</button>
+    <button data-val="top-left">top-left</button>
+    <button data-val="top-right">top-right</button>
+    <button data-val="bottom-left">bottom-left</button>
+    <button data-val="bottom-right">bottom-right</button>
+    <button data-val="center">center</button>
+  </div>
+  <div class="controls" data-cc-picker="scrim">
+    <button data-val="toggle">toggle scrim</button>
+  </div>
+
   <h2>Current State</h2>
   <pre id="state">No consent data yet.</pre>
 
@@ -34,12 +71,18 @@ import Layout from '../layouts/Layout.astro';
     // Harness hook (#80): echo URL params onto <html data-cc-test-*> so
     // Playwright fixtures (see `playground/e2e/helpers.ts` → `openBanner`)
     // can parameterize the page without a build rebuild. Params currently
-    // recognized: layout, categoriesOnBanner, showCounter, equalWeight.
-    // Feature PRs (#39, #44, #77, #79) read these attrs to flip variants;
-    // before those land the attrs are inert and specs can `test.fixme()`.
+    // recognized: layout, position, scrim, categoriesOnBanner, showCounter,
+    // equalWeight.
     (function () {
       const params = new URLSearchParams(window.location.search);
-      const known = ['layout', 'categoriesOnBanner', 'showCounter', 'equalWeight'];
+      const known = [
+        'layout',
+        'position',
+        'scrim',
+        'categoriesOnBanner',
+        'showCounter',
+        'equalWeight',
+      ];
       for (const key of known) {
         const value = params.get(key);
         if (value === null) continue;
@@ -71,8 +114,80 @@ import Layout from '../layouts/Layout.astro';
       refreshState();
     });
 
+    // Live picker — mutates the banner's data-cc-* attributes and the scrim
+    // element so reviewers can eyeball every layout/position combination
+    // without a reload. Validation mirrors the server-side resolver.
+    const VALID_POSITIONS = {
+      bar: ['bottom', 'top'],
+      box: ['bottom-right', 'bottom-left', 'top-right', 'top-left'],
+      cloud: ['bottom', 'top'],
+      popup: ['center'],
+    };
+    const DEFAULT_POSITION = {
+      bar: 'bottom',
+      box: 'bottom-right',
+      cloud: 'bottom',
+      popup: 'center',
+    };
+
+    function refreshPositionButtons(layout) {
+      const valid = VALID_POSITIONS[layout] || [];
+      document
+        .querySelectorAll('[data-cc-picker="position"] button')
+        .forEach((btn) => {
+          const val = btn.getAttribute('data-val');
+          btn.disabled = !valid.includes(val);
+        });
+    }
+
+    function applyBannerVariant(layout, position, scrim) {
+      const banner = document.getElementById('cc-banner');
+      if (!banner) return;
+      if (layout) {
+        banner.setAttribute('data-cc-layout', layout);
+        // Popup forces scrim on; bar/box force it off; cloud is a passthrough.
+        if (layout === 'popup') scrim = true;
+        if (layout === 'bar' || layout === 'box') scrim = false;
+      }
+      const effectiveLayout = layout || banner.getAttribute('data-cc-layout') || 'bar';
+      let effectivePosition = position || banner.getAttribute('data-cc-position');
+      if (!VALID_POSITIONS[effectiveLayout].includes(effectivePosition)) {
+        effectivePosition = DEFAULT_POSITION[effectiveLayout];
+      }
+      banner.setAttribute('data-cc-position', effectivePosition);
+      refreshPositionButtons(effectiveLayout);
+
+      // Manage the scrim element — create / destroy as needed so it matches
+      // whatever the banner currently wants.
+      const currentScrim = document.getElementById('cc-banner-scrim');
+      const wantScrim =
+        scrim === undefined ? banner.getAttribute('data-cc-scrim') === 'true' : scrim;
+      banner.setAttribute('data-cc-scrim', wantScrim ? 'true' : 'false');
+      if (wantScrim && !currentScrim) {
+        const s = document.createElement('div');
+        s.className = 'cc-banner-scrim cc-visible';
+        s.id = 'cc-banner-scrim';
+        s.setAttribute('data-testid', 'cc-banner-scrim');
+        s.setAttribute('aria-hidden', 'true');
+        banner.parentElement?.insertBefore(s, banner);
+      } else if (!wantScrim && currentScrim) {
+        currentScrim.remove();
+      }
+    }
+
     document.addEventListener('astro:page-load', () => {
       refreshState();
+
+      // Mirror the banner's current layout onto the position picker so
+      // invalid buttons are greyed out from first paint. The banner may
+      // mount a tick after page-load, so poll briefly.
+      const initialLayout = () => {
+        const banner = document.getElementById('cc-banner');
+        const layout = banner?.getAttribute('data-cc-layout') || 'bar';
+        refreshPositionButtons(layout);
+      };
+      if (document.getElementById('cc-banner')) initialLayout();
+      else requestAnimationFrame(initialLayout);
 
       document.getElementById('btn-show')?.addEventListener('click', () => {
         window.astroConsent?.show();
@@ -90,6 +205,28 @@ import Layout from '../layouts/Layout.astro';
       document.getElementById('btn-get')?.addEventListener('click', () => {
         refreshState();
       });
+
+      document
+        .querySelector('[data-cc-picker="layout"]')
+        ?.addEventListener('click', (e) => {
+          const btn = e.target instanceof HTMLElement ? e.target.closest('button') : null;
+          const val = btn?.getAttribute('data-val');
+          if (val) applyBannerVariant(val);
+        });
+      document
+        .querySelector('[data-cc-picker="position"]')
+        ?.addEventListener('click', (e) => {
+          const btn = e.target instanceof HTMLElement ? e.target.closest('button') : null;
+          const val = btn?.getAttribute('data-val');
+          if (val) applyBannerVariant(undefined, val);
+        });
+      document
+        .querySelector('[data-cc-picker="scrim"]')
+        ?.addEventListener('click', () => {
+          const banner = document.getElementById('cc-banner');
+          const current = banner?.getAttribute('data-cc-scrim') === 'true';
+          applyBannerVariant(undefined, undefined, !current);
+        });
     });
   </script>
 </Layout>


### PR DESCRIPTION
Closes #39.

## Summary

- Adds `ui.banner.layout` / `ui.banner.position` / `ui.banner.scrim` config, surfacing four variants — `bar`, `box`, `cloud`, `popup`.
- Single banner element; layouts are selected via `data-cc-layout` / `data-cc-position` / `data-cc-scrim` attributes so consumers can override per-variant styling without forking.
- Default remains `bar` + `bottom` — no visual change for existing installations.
- Invalid layout/position pairings warn in dev and fall back to the layout's default. Popup forces scrim on; bar/box force it off; cloud is a passthrough. Scrim is click-inert by design.
- New CSS tokens: `--cc-banner-max-width`, `--cc-box-width`, `--cc-popup-width`, `--cc-banner-offset`.
- README + package README get a new "Choose a banner layout" section with ASCII sketches, position-validity table, and the new tokens; `ui` is now documented in the Configuration interface block.
- Playground `/` gets a live layout/position/scrim picker; invalid position buttons grey out as the layout changes.
- Changeset entry added; minor bump.

## Known follow-ups

User has flagged minor visual glitches to be addressed during the end-of-v0.4 polish pass alongside #44 / #78 — deliberately deferred to avoid per-variant churn while those issues are still in flight.

## Test plan

- [ ] `pnpm --filter @zdenekkurecka/astro-consent build` passes
- [ ] `pnpm --filter playground dev` — open `/`, cycle every layout × position combination via the picker
- [ ] Confirm default config (no `ui.banner` override) still renders the bottom bar exactly as before
- [ ] Confirm `popup` always shows scrim, `bar`/`box` never, `cloud` toggles with `ui.banner.scrim`
- [ ] Confirm invalid position buttons are disabled and a `console.warn` fires for a bad manual config
- [ ] URL harness: `/?layout=cloud&position=top&scrim=true` applies without manual clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
