### PR TITLE
feat(ui): single-layer consent — toggles inline on the banner (#44)

### DIFF
--- a/.changeset/single-layer-consent.md
+++ b/.changeset/single-layer-consent.md
@@ -1,0 +1,37 @@
+---
+'@zdenekkurecka/astro-consent': minor
+---
+
+Single-layer consent flow: category toggles can now be rendered directly on the banner, eliminating the modal click for sites with few categories.
+
+```ts
+cookieConsent({
+  version: 1,
+  categories: { /* ... */ },
+  ui: {
+    banner: {
+      layout: 'cloud',
+      categoriesOnBanner: true,
+    },
+  },
+});
+```
+
+The banner starts collapsed. Clicking **Customize** expands it in place, revealing the toggles and morphing the action labels (Customize ↔ Hide preferences, Accept all ↔ Save preferences). The "Reject optional" button fades and collapses to zero width once expanded — it's redundant when the user has direct switch control.
+
+A new `×` close button (label: `text.dismissAriaLabel`) lets the user dismiss the banner without recording consent; it returns on the next page load.
+
+`window.astroConsent.showPreferences()` flips the banner into expanded mode instead of opening the modal — the modal is not injected at all in single-layer mode.
+
+Layout fit:
+
+| Layout  | Recommended for single-layer? |
+| ------- | ----------------------------- |
+| `cloud` | yes                           |
+| `popup` | yes                           |
+| `bar`   | works, tighter                |
+| `box`   | not recommended (too narrow)  |
+
+New text keys: `hidePreferences` (default `"Hide preferences"`) and `dismissAriaLabel` (default `"Dismiss"`). Behavior with `categoriesOnBanner: false` is unchanged.
+
+Closes #44.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
   - [Customise banner & modal text (and localize it)](#customise-banner--modal-text-and-localize-it)
   - [Choose a banner layout](#choose-a-banner-layout)
   - [Theme the UI](#theme-the-ui)
+  - [Single-layer consent (toggles on the banner)](#single-layer-consent-toggles-on-the-banner)
   - [Use with a strict Content Security Policy](#use-with-a-strict-content-security-policy)
   - [Debug mode](#debug-mode)
 - [Runtime API](#runtime-api)
@@ -64,6 +65,8 @@ they force you to serialize your tracker callbacks into a JSON config.
 ## Features
 
 - **Banner + preferences modal** out of the box
+- **Single-layer consent** — toggles inline on the banner with one config
+  flag, eliminating the modal click for sites with few categories
 - **Category-based consent** (`analytics`, `marketing`, … — whatever you
   declare), plus an always-on implicit `essential` category
 - **Versioned consent** — bump a number to re-prompt every user
@@ -894,6 +897,59 @@ override per-variant styling without forking the integration.
 }
 ```
 
+### Single-layer consent (toggles on the banner)
+
+The default flow is two layers: banner → preferences modal. For sites with
+only 2–3 categories, the modal can feel excessive. Set
+`ui.banner.categoriesOnBanner: true` to render the toggles inline on the
+banner and skip the modal entirely:
+
+```ts
+cookieConsent({
+  version: 1,
+  categories: {
+    analytics: { label: 'Analytics', description: '…', default: false },
+    marketing: { label: 'Marketing', description: '…', default: false },
+  },
+  ui: {
+    banner: {
+      layout: 'cloud',
+      categoriesOnBanner: true,
+    },
+  },
+});
+```
+
+The banner starts collapsed. Clicking **Customize** expands it in place and
+morphs the action labels:
+
+| State     | Ghost button       | Primary button     |
+| --------- | ------------------ | ------------------ |
+| Collapsed | `text.manage`      | `text.acceptAll`   |
+| Expanded  | `text.hidePreferences` | `text.savePreferences` |
+
+Once expanded, the "Reject optional" button fades and collapses to zero
+width — it's redundant when the user has direct switch control. A small
+`×` close button (labelled via `text.dismissAriaLabel`) lets the user
+dismiss the banner without recording consent; it will reappear on the
+next page load.
+
+`window.astroConsent.showPreferences()` continues to work — in single-layer
+mode it flips the banner into expanded mode instead of opening the modal.
+
+**Layout fit.** Single-layer mode works best in layouts with room for the
+expanded card:
+
+| Layout  | Fit                                                    |
+| ------- | ------------------------------------------------------ |
+| `cloud` | ✅ ideal — centered padded strip with room to expand   |
+| `popup` | ✅ centered overlay; scrolls if categories overflow    |
+| `bar`   | works, but vertical space is tight                     |
+| `box`   | not recommended — typically too narrow                 |
+
+**Behavior when `false` (default).** Two-layer flow preserved. No
+breaking change for existing installations.
+
 ### Use with a strict Content Security Policy
 
 The integration is compatible with strict CSPs out of the box:
@@ -1082,9 +1138,15 @@ if you don't declare it, and the narrow type kicks in the moment you do.
   `aria-disabled="true"` on the locked essential category). `Space` and
   `Enter` flip them; focus rings follow `:focus-visible`.
 - Respects `prefers-reduced-motion: reduce` — the banner/modal fade, the
-  switch thumb transition, and the overlay fade are all dropped when the
-  user has opted into reduced motion.
+  switch thumb transition, the overlay fade, and the single-layer
+  expand/collapse + reject-button collapse are all dropped when the user
+  has opted into reduced motion.
 - All buttons have `type="button"` so they never submit ambient forms.
+- In single-layer mode (`ui.banner.categoriesOnBanner: true`), the banner
+  retains `role="dialog"` only when paired with the `popup` layout (the
+  card sits atop a scrim); other layouts use `role="region"` with
+  `aria-label="Cookie consent"`. Focus moves to the first interactive
+  switch when the banner expands.
 
 ## Repository layout
 

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -28,6 +28,11 @@ import {
   isModalVisible,
   getModalSelections,
   updateModalToggles,
+  getBannerSelections,
+  updateBannerToggles,
+  isCategoriesOnBanner,
+  isBannerExpanded,
+  setBannerExpanded,
   handleModalTabTrap,
 } from './ui.js';
 import { activateBlockedResources, initScriptBlocker } from './scripts.js';
@@ -148,8 +153,12 @@ export function initConsentManager(config: SerializableConsentConfig): void {
     listenerAttached = true;
 
     // Custom [role="switch"] toggles — no native input, so we handle click +
-    // Space/Enter explicitly. Scoped to the modal so script-blocking markup
-    // that reuses `data-cc-category` on <script>/<iframe> can't match.
+    // Space/Enter explicitly. Scoped to either container so script-blocking
+    // markup that reuses `data-cc-category` on <script>/<iframe> can't match
+    // (the selector requires `[role="switch"]`, but we keep the explicit
+    // container scoping as a belt-and-braces guard).
+    const TOGGLE_SELECTOR =
+      '#cc-modal [role="switch"][data-cc-category], #cc-banner [role="switch"][data-cc-category]';
     const toggleSwitch = (sw: HTMLElement): void => {
       if (sw.getAttribute('data-locked') === 'true') return;
       const next = sw.getAttribute('aria-checked') !== 'true';
@@ -157,17 +166,13 @@ export function initConsentManager(config: SerializableConsentConfig): void {
     };
 
     document.addEventListener('click', (e) => {
-      const sw = (e.target as HTMLElement).closest<HTMLElement>(
-        '#cc-modal [role="switch"][data-cc-category]',
-      );
+      const sw = (e.target as HTMLElement).closest<HTMLElement>(TOGGLE_SELECTOR);
       if (sw) toggleSwitch(sw);
     });
 
     document.addEventListener('keydown', (e) => {
       if (e.key !== ' ' && e.key !== 'Enter') return;
-      const sw = (e.target as HTMLElement).closest<HTMLElement>(
-        '#cc-modal [role="switch"][data-cc-category]',
-      );
+      const sw = (e.target as HTMLElement).closest<HTMLElement>(TOGGLE_SELECTOR);
       if (!sw) return;
       e.preventDefault();
       toggleSwitch(sw);
@@ -182,6 +187,21 @@ export function initConsentManager(config: SerializableConsentConfig): void {
       switch (action) {
         case 'accept-all':
         case 'modal-accept-all': {
+          // In single-layer mode, the primary button morphs to "Save
+          // preferences" once the banner is expanded — so an "accept-all"
+          // click while expanded is really a save-preferences with the
+          // current banner switch state.
+          if (action === 'accept-all' && isCategoriesOnBanner() && isBannerExpanded()) {
+            const selections = getBannerSelections();
+            const isUpdate = !needsConsent(config.version, config.maxAgeDays);
+            log(`save-preferences (banner) →`, selections, isUpdate ? '(update)' : '(initial)');
+            const state = savePreferences(config, selections);
+            persist(state);
+            hideBanner();
+            consentFiredThisSession = true;
+            emit(isUpdate ? CHANGE_EVENT : CONSENT_EVENT, state);
+            break;
+          }
           log(`${action} →`, 'all categories: true');
           const isUpdate = !needsConsent(config.version, config.maxAgeDays);
           const state = acceptAll(config);
@@ -207,19 +227,27 @@ export function initConsentManager(config: SerializableConsentConfig): void {
         }
 
         case 'manage': {
-          hideBanner();
-          // Sync toggles with current state or defaults.
+          // Sync toggles with current state or defaults regardless of
+          // whether we open the modal or just expand the banner — the same
+          // markup/data-cc-category attributes are read by both paths.
           const current = readConsent();
+          const seed: Record<string, boolean> = {};
           if (current) {
-            updateModalToggles(current.categories);
+            Object.assign(seed, current.categories);
           } else {
-            // After reset: show defaults from config.
-            const defaults: Record<string, boolean> = {};
             for (const [key, cat] of Object.entries(config.categories)) {
-              defaults[key] = cat.default;
+              seed[key] = cat.default;
             }
-            updateModalToggles(defaults);
           }
+
+          if (isCategoriesOnBanner()) {
+            updateBannerToggles(seed);
+            setBannerExpanded(!isBannerExpanded());
+            break;
+          }
+
+          hideBanner();
+          updateModalToggles(seed);
           showModal();
           break;
         }
@@ -242,6 +270,16 @@ export function initConsentManager(config: SerializableConsentConfig): void {
           if (needsConsent(config.version, config.maxAgeDays)) {
             showBanner();
           }
+          break;
+        }
+
+        case 'dismiss': {
+          // Single-layer banner's `×` button — hide without recording
+          // consent. The banner re-appears on the next page load if no
+          // valid consent record is stored, which is the conservative
+          // default for compliance (no implicit choice).
+          log('dismiss');
+          hideBanner();
           break;
         }
 
@@ -342,17 +380,28 @@ export function initConsentManager(config: SerializableConsentConfig): void {
     },
     showPreferences: () => {
       injectUI(config, text);
-      hideBanner();
       const current = readConsent();
+      const seed: Record<string, boolean> = {};
       if (current) {
-        updateModalToggles(current.categories);
+        Object.assign(seed, current.categories);
       } else {
-        const defaults: Record<string, boolean> = {};
         for (const [key, cat] of Object.entries(config.categories)) {
-          defaults[key] = cat.default;
+          seed[key] = cat.default;
         }
-        updateModalToggles(defaults);
       }
+
+      if (isCategoriesOnBanner()) {
+        // Single-layer mode: there is no modal to open — show the banner
+        // (in case it was hidden) and flip it into expanded state so the
+        // toggles are visible.
+        updateBannerToggles(seed);
+        showBanner();
+        setBannerExpanded(true);
+        return;
+      }
+
+      hideBanner();
+      updateModalToggles(seed);
       showModal();
     },
   };

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -300,6 +300,142 @@
   justify-content: center;
 }
 
+/* ── Single-layer banner (categoriesOnBanner) ───────────────
+ *
+ * When `ui.banner.categoriesOnBanner: true`, the banner renders the
+ * category toggles inline and starts collapsed. Clicking "Customize"
+ * sets `data-cc-expanded="true"` on the banner, which:
+ *   • slides the `.cc-categories` block in via max-height + opacity,
+ *   • swaps the morphing button labels (Customize ↔ Hide preferences,
+ *     Accept all ↔ Save preferences) via `[data-cc-label]`,
+ *   • fades and collapses the "Reject optional" button to zero width.
+ *
+ * The single-layer banner forces a column layout in `.cc-banner-inner`
+ * across every variant — categories never sit beside the text.
+ */
+
+.cc-banner[data-cc-categories-on-banner='true'] {
+  position: fixed;
+}
+
+.cc-banner[data-cc-categories-on-banner='true'] .cc-banner-inner {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 1rem;
+}
+
+.cc-banner-close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--cc-radius-sm);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--cc-text-mute);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  z-index: 1;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.cc-banner-close:hover {
+  background-color: rgba(var(--cc-tint-rgb), 0.06);
+  color: var(--cc-text);
+  border-color: var(--cc-border);
+}
+
+.cc-banner-close:focus-visible {
+  outline: 2px solid var(--cc-primary);
+  outline-offset: 2px;
+}
+
+/* Categories container — collapsed by default; expands on
+ * `data-cc-expanded="true"`. Animating max-height is approximate but cheap;
+ * 32rem is well above the typical 3-category footprint. */
+.cc-banner[data-cc-categories-on-banner='true'] .cc-categories {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  transition: max-height 0.35s ease, opacity 0.25s ease, margin 0.25s ease;
+}
+
+.cc-banner[data-cc-categories-on-banner='true'][data-cc-expanded='true']
+  .cc-categories {
+  max-height: 32rem;
+  opacity: 1;
+}
+
+/* Label morphing for the morphing buttons. Each button renders both labels
+ * side-by-side — only one is visible based on banner expanded state. */
+.cc-btn-label[data-cc-label='expanded'],
+.cc-banner[data-cc-categories-on-banner='true'][data-cc-expanded='true']
+  .cc-btn-label[data-cc-label='collapsed'] {
+  display: none;
+}
+
+.cc-banner[data-cc-categories-on-banner='true'][data-cc-expanded='true']
+  .cc-btn-label[data-cc-label='expanded'] {
+  display: inline;
+}
+
+/* Ghost variant for the Customize / Hide preferences button — borderless,
+ * tertiary visual weight so the primary actions dominate. */
+.cc-btn-ghost {
+  background-color: transparent;
+  color: var(--cc-text-dim);
+  border-color: transparent;
+}
+
+.cc-btn-ghost:hover {
+  background-color: rgba(var(--cc-tint-rgb), 0.04);
+  color: var(--cc-text);
+}
+
+/* Reject-collapse — when the user expands and gains direct toggle control,
+ * "Reject optional" becomes redundant. Two-phase transition: fade + scale
+ * (180ms), then width/padding/border collapse via `transition-delay` so the
+ * gap closes only after the button is invisible (prototype lines 283–308). */
+.cc-banner[data-cc-categories-on-banner='true'] .cc-banner-reject {
+  opacity: 1;
+  transform: scale(1);
+  transform-origin: right center;
+  overflow: hidden;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.cc-banner[data-cc-categories-on-banner='true'][data-cc-expanded='true']
+  .cc-banner-reject {
+  opacity: 0;
+  transform: scale(0.92);
+  pointer-events: none;
+  width: 0;
+  padding: 0;
+  border-width: 0;
+  margin-left: -0.5rem; /* consume the .cc-banner-actions gap */
+  transition:
+    opacity 0.18s ease,
+    transform 0.18s ease,
+    width 0s linear 0.18s,
+    padding 0s linear 0.18s,
+    margin 0s linear 0.18s,
+    border-width 0s linear 0.18s;
+}
+
+/* Reduced motion: instant expand/collapse, no fade-out delay on reject. */
+@media (prefers-reduced-motion: reduce) {
+  .cc-banner[data-cc-categories-on-banner='true'] .cc-categories,
+  .cc-banner[data-cc-categories-on-banner='true'] .cc-banner-reject {
+    transition: none !important;
+  }
+}
+
 /* ── Modal ──────────────────────────────────────────────── */
 
 .cc-overlay {

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -159,6 +159,23 @@ export interface ConsentBannerConfig {
    * @default false
    */
   scrim?: boolean;
+
+  /**
+   * Render category toggles directly inside the banner — a single-layer
+   * consent flow that eliminates the extra click into the modal. The banner
+   * starts collapsed and expands in place when the user clicks "Customize";
+   * primary/ghost button labels morph (Customize ↔ Hide preferences,
+   * Accept all ↔ Save preferences) and the "Reject optional" button fades
+   * away once expanded.
+   *
+   * Best paired with `cloud` or `popup` layouts (room for the expanded
+   * state) and ≤3 categories. When `true`, the preferences modal is not
+   * injected into the DOM; `astroConsent.showPreferences()` flips the
+   * banner into expanded mode instead.
+   *
+   * @default false
+   */
+  categoriesOnBanner?: boolean;
 }
 
 /** Visual/UI-level configuration for the consent banner and modal. */
@@ -206,6 +223,12 @@ export interface ConsentText<K extends string = string> {
   modalTitle?: string;
   closeAriaLabel?: string;
   savePreferences?: string;
+
+  // Single-layer banner (`ui.banner.categoriesOnBanner: true`)
+  /** Ghost button label when the banner is expanded. Default `"Hide preferences"`. */
+  hidePreferences?: string;
+  /** ARIA label on the banner's close (×) button. Default `"Dismiss"`. */
+  dismissAriaLabel?: string;
 
   // Essential category
   essentialLabel?: string;

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -25,6 +25,8 @@ const BUILT_IN_DEFAULTS: ResolvedConsentText = {
   modalTitle: 'Cookie preferences',
   closeAriaLabel: 'Close preferences',
   savePreferences: 'Save preferences',
+  hidePreferences: 'Hide preferences',
+  dismissAriaLabel: 'Dismiss',
   essentialLabel: 'Essential',
   essentialDescription: 'Required for the website to function. Cannot be disabled.',
   essentialBadge: 'Required',
@@ -51,6 +53,8 @@ function mergeText(base: ResolvedConsentText, layer: ConsentText | undefined): R
   if (layer.modalTitle !== undefined) next.modalTitle = layer.modalTitle;
   if (layer.closeAriaLabel !== undefined) next.closeAriaLabel = layer.closeAriaLabel;
   if (layer.savePreferences !== undefined) next.savePreferences = layer.savePreferences;
+  if (layer.hidePreferences !== undefined) next.hidePreferences = layer.hidePreferences;
+  if (layer.dismissAriaLabel !== undefined) next.dismissAriaLabel = layer.dismissAriaLabel;
   if (layer.essentialLabel !== undefined) next.essentialLabel = layer.essentialLabel;
   if (layer.essentialDescription !== undefined) {
     next.essentialDescription = layer.essentialDescription;
@@ -175,6 +179,8 @@ export interface ResolvedBannerOptions {
   layout: BannerLayout;
   position: BannerPosition;
   scrim: boolean;
+  /** Render category toggles inline on the banner (single-layer flow). */
+  categoriesOnBanner: boolean;
 }
 
 /**
@@ -219,7 +225,13 @@ export function resolveBannerOptions(
   if (layout === 'popup') scrim = true;
   else if (layout === 'bar' || layout === 'box') scrim = false;
 
-  return { layout, position, scrim };
+  const harnessCategoriesOnBanner = html?.getAttribute('data-cc-test-categories-on-banner');
+  const categoriesOnBanner =
+    harnessCategoriesOnBanner != null
+      ? harnessCategoriesOnBanner === 'true'
+      : banner.categoriesOnBanner === true;
+
+  return { layout, position, scrim, categoriesOnBanner };
 }
 
 let previouslyFocused: HTMLElement | null = null;
@@ -274,6 +286,25 @@ function createBannerHTML(
   const scrimHTML = banner.scrim
     ? `<div class="cc-banner-scrim" id="${BANNER_SCRIM_ID}" data-testid="cc-banner-scrim" aria-hidden="true"></div>`
     : '';
+
+  // Single-layer mode swaps the action row for a label-morphing trio
+  // (Customize ↔ Hide preferences, Accept all ↔ Save preferences) and
+  // renders the inline categories + dismiss button below.
+  const singleLayer = banner.categoriesOnBanner;
+  const categoriesHTML = singleLayer ? createBannerCategoriesHTML(config, text) : '';
+  const closeBtnHTML = singleLayer
+    ? `<button type="button" class="cc-banner-close" data-cc="dismiss" aria-label="${escapeHtml(text.dismissAriaLabel)}"><svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="2" x2="10" y2="10"/><line x1="10" y1="2" x2="2" y2="10"/></svg></button>`
+    : '';
+  const manageButtonHTML = singleLayer
+    ? `<button type="button" class="cc-btn cc-btn-ghost" data-cc="manage"><span class="cc-btn-label" data-cc-label="collapsed">${escapeHtml(text.manage)}</span><span class="cc-btn-label" data-cc-label="expanded">${escapeHtml(text.hidePreferences)}</span></button>`
+    : `<button type="button" class="cc-btn cc-btn-secondary" data-cc="manage">${escapeHtml(text.manage)}</button>`;
+  const acceptButtonHTML = singleLayer
+    ? `<button type="button" class="cc-btn cc-btn-primary" data-cc="accept-all"><span class="cc-btn-label" data-cc-label="collapsed">${escapeHtml(text.acceptAll)}</span><span class="cc-btn-label" data-cc-label="expanded">${escapeHtml(text.savePreferences)}</span></button>`
+    : `<button type="button" class="cc-btn cc-btn-primary" data-cc="accept-all">${escapeHtml(text.acceptAll)}</button>`;
+
+  const expandedAttr = singleLayer ? `data-cc-expanded="false"` : '';
+  const singleLayerAttr = singleLayer ? `data-cc-categories-on-banner="true"` : '';
+
   return `
     ${scrimHTML}
     <div
@@ -283,21 +314,53 @@ function createBannerHTML(
       data-cc-layout="${banner.layout}"
       data-cc-position="${banner.position}"
       data-cc-scrim="${banner.scrim ? 'true' : 'false'}"
+      ${singleLayerAttr}
+      ${expandedAttr}
       ${roleAttrs}
       aria-hidden="true"
     >
+      ${closeBtnHTML}
       <div class="cc-banner-inner">
         <p class="cc-banner-text">
           ${escapeHtml(text.bannerText)}
           ${policyLink}
         </p>
+        ${categoriesHTML}
         <div class="cc-banner-actions">
-          <button type="button" class="cc-btn cc-btn-primary" data-cc="accept-all">${escapeHtml(text.acceptAll)}</button>
-          <button type="button" class="cc-btn cc-btn-primary" data-cc="reject-all">${escapeHtml(text.rejectAll)}</button>
-          <button type="button" class="cc-btn cc-btn-secondary" data-cc="manage">${escapeHtml(text.manage)}</button>
+          ${acceptButtonHTML}
+          <button type="button" class="cc-btn cc-btn-primary cc-banner-reject" data-cc="reject-all">${escapeHtml(text.rejectAll)}</button>
+          ${manageButtonHTML}
         </div>
       </div>
     </div>`;
+}
+
+function createBannerCategoriesHTML(
+  config: SerializableConsentConfig,
+  text: ResolvedConsentText,
+): string {
+  const essentialToggle = createCategoryToggle(
+    'essential',
+    text.essentialLabel,
+    text.essentialDescription,
+    true,
+    true,
+    text.badgeRequired,
+  );
+  const categoryToggles = Object.entries(config.categories)
+    .map(([key, cat]) => {
+      const resolved = resolveCategoryText(key, cat, text);
+      return createCategoryToggle(
+        key,
+        resolved.label,
+        resolved.description,
+        false,
+        cat.default,
+        text.badgeOptional,
+      );
+    })
+    .join('');
+  return `<div class="cc-categories" data-cc-banner-categories>${essentialToggle}${categoryToggles}</div>`;
 }
 
 function createCategoryToggle(
@@ -402,7 +465,11 @@ export function injectUI(config: SerializableConsentConfig, text: ResolvedConsen
   const banner = resolveBannerOptions(config);
   const container = document.createElement('div');
   container.id = CONTAINER_ID;
-  container.innerHTML = createBannerHTML(config, text, banner) + createModalHTML(config, text);
+  // Single-layer mode renders categories inline on the banner, so the modal
+  // is never reachable — skip injecting it to keep the DOM minimal and avoid
+  // a phantom dialog that `Tab` could land in.
+  const modalHTML = banner.categoriesOnBanner ? '' : createModalHTML(config, text);
+  container.innerHTML = createBannerHTML(config, text, banner) + modalHTML;
   document.body.appendChild(container);
 
   // Apply forced color mode (if any). "auto" / undefined leaves the
@@ -568,9 +635,24 @@ export function isModalVisible(): boolean {
 // script-blocking markup (which reuses `data-cc-category` on <script>/<iframe>
 // elements) doesn't leak into modal state reads.
 const MODAL_TOGGLE_SELECTOR = `#${MODAL_ID} [role="switch"][data-cc-category]`;
+// Mirror selector for single-layer mode where toggles live on the banner
+// rather than in the modal. Same scoping rationale as `MODAL_TOGGLE_SELECTOR`.
+const BANNER_TOGGLE_SELECTOR = `#${BANNER_ID} [role="switch"][data-cc-category]`;
 
-export function updateModalToggles(categories: Record<string, boolean>): void {
-  const switches = document.querySelectorAll<HTMLElement>(MODAL_TOGGLE_SELECTOR);
+function readSelections(selector: string): Record<string, boolean> {
+  const selections: Record<string, boolean> = {};
+  const switches = document.querySelectorAll<HTMLElement>(selector);
+  for (const sw of switches) {
+    const key = sw.getAttribute('data-cc-category');
+    if (key && key !== 'essential') {
+      selections[key] = sw.getAttribute('aria-checked') === 'true';
+    }
+  }
+  return selections;
+}
+
+function applyToggleState(selector: string, categories: Record<string, boolean>): void {
+  const switches = document.querySelectorAll<HTMLElement>(selector);
   for (const sw of switches) {
     const key = sw.getAttribute('data-cc-category');
     if (key && sw.getAttribute('data-locked') !== 'true') {
@@ -579,14 +661,53 @@ export function updateModalToggles(categories: Record<string, boolean>): void {
   }
 }
 
+export function updateModalToggles(categories: Record<string, boolean>): void {
+  applyToggleState(MODAL_TOGGLE_SELECTOR, categories);
+}
+
 export function getModalSelections(): Record<string, boolean> {
-  const selections: Record<string, boolean> = {};
-  const switches = document.querySelectorAll<HTMLElement>(MODAL_TOGGLE_SELECTOR);
-  for (const sw of switches) {
-    const key = sw.getAttribute('data-cc-category');
-    if (key && key !== 'essential') {
-      selections[key] = sw.getAttribute('aria-checked') === 'true';
-    }
+  return readSelections(MODAL_TOGGLE_SELECTOR);
+}
+
+export function updateBannerToggles(categories: Record<string, boolean>): void {
+  applyToggleState(BANNER_TOGGLE_SELECTOR, categories);
+}
+
+export function getBannerSelections(): Record<string, boolean> {
+  return readSelections(BANNER_TOGGLE_SELECTOR);
+}
+
+/**
+ * Returns `true` when the rendered banner is in single-layer mode (categories
+ * inline). Read off the live DOM rather than re-resolving config so
+ * `setBannerExpanded` and the click handlers stay cheap.
+ */
+export function isCategoriesOnBanner(): boolean {
+  const banner = document.getElementById(BANNER_ID);
+  return banner?.getAttribute('data-cc-categories-on-banner') === 'true';
+}
+
+export function isBannerExpanded(): boolean {
+  const banner = document.getElementById(BANNER_ID);
+  return banner?.getAttribute('data-cc-expanded') === 'true';
+}
+
+/**
+ * Flip the single-layer banner between collapsed and expanded. Sets
+ * `data-cc-expanded` (read by CSS to drive the height/opacity transition and
+ * the button-label morphing) and moves focus into the first interactive
+ * switch when expanding so keyboard users land on the new controls.
+ */
+export function setBannerExpanded(expanded: boolean): void {
+  const banner = document.getElementById(BANNER_ID);
+  if (!banner) return;
+  banner.setAttribute('data-cc-expanded', expanded ? 'true' : 'false');
+  if (expanded) {
+    requestAnimationFrame(() => {
+      const firstSwitch = banner.querySelector<HTMLElement>(
+        '[role="switch"][data-cc-category]:not([data-locked="true"])',
+      );
+      firstSwitch?.focus();
+    });
   }
-  return selections;
 }

--- a/playground/e2e/variants.spec.ts
+++ b/playground/e2e/variants.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { expectBannerVisible, openBanner } from './helpers';
+import { expectBannerVisible, getConsentState, openBanner, sel } from './helpers';
 
 // Variant matrix smoke tests (#39, #44, #77, #79). Any variant that is not
 // yet implemented passes `openBanner(…)` through and falls back to the
@@ -40,9 +40,86 @@ test.describe('Variants', () => {
     });
   });
 
-  test.fixme('categoriesOnBanner renders toggles inline on the banner (#44)', async ({ page }) => {
-    const { banner } = await openBanner(page, { categoriesOnBanner: true });
-    await expect(banner.locator('[data-cc-category="analytics"]')).toBeVisible();
+  test.describe('categoriesOnBanner (#44)', () => {
+    test('renders the toggles inline and skips modal injection', async ({ page }) => {
+      const { banner, modal } = await openBanner(page, {
+        categoriesOnBanner: true,
+        layout: 'cloud',
+      });
+      // Switches live on the banner, not the modal.
+      await expect(banner.locator(sel.toggleLabel('analytics'))).toBeAttached();
+      await expect(banner.locator(sel.toggleLabel('marketing'))).toBeAttached();
+      // Modal is skipped entirely — no #cc-modal element in the DOM.
+      await expect(modal).toHaveCount(0);
+      // Banner starts collapsed.
+      await expect(banner).toHaveAttribute('data-cc-expanded', 'false');
+    });
+
+    test('Customize toggles the expanded state', async ({ page }) => {
+      const { banner, manage } = await openBanner(page, {
+        categoriesOnBanner: true,
+        layout: 'cloud',
+      });
+      await manage.click();
+      await expect(banner).toHaveAttribute('data-cc-expanded', 'true');
+      await manage.click();
+      await expect(banner).toHaveAttribute('data-cc-expanded', 'false');
+    });
+
+    test('expanded primary button saves the current toggle selection', async ({ page }) => {
+      const { banner, manage, accept } = await openBanner(page, {
+        categoriesOnBanner: true,
+        layout: 'cloud',
+      });
+      await manage.click(); // expand
+      // Flip the analytics switch on, leave marketing off.
+      await banner.locator(sel.toggleLabel('analytics')).click();
+      await accept.click(); // primary morphs to "Save preferences"
+      await expectBannerVisible(page, false);
+      const state = await getConsentState(page);
+      expect(state?.categories).toMatchObject({
+        essential: true,
+        analytics: true,
+        marketing: false,
+      });
+    });
+
+    test('collapsed accept-all still grants every category', async ({ page }) => {
+      const { accept } = await openBanner(page, {
+        categoriesOnBanner: true,
+        layout: 'cloud',
+      });
+      await accept.click(); // collapsed → behaves like accept-all
+      await expectBannerVisible(page, false);
+      const state = await getConsentState(page);
+      expect(state?.categories).toMatchObject({
+        essential: true,
+        analytics: true,
+        marketing: true,
+      });
+    });
+
+    test('dismiss hides the banner without recording consent', async ({ page }) => {
+      const { banner } = await openBanner(page, {
+        categoriesOnBanner: true,
+        layout: 'cloud',
+      });
+      await banner.locator('[data-cc="dismiss"]').click();
+      await expectBannerVisible(page, false);
+      const state = await getConsentState(page);
+      expect(state).toBeNull();
+    });
+
+    test('showPreferences() flips the banner into expanded mode', async ({ page }) => {
+      const { banner, modal } = await openBanner(page, {
+        categoriesOnBanner: true,
+        layout: 'cloud',
+      });
+      await page.evaluate(() => window.astroConsent?.showPreferences());
+      await expect(banner).toHaveAttribute('data-cc-expanded', 'true');
+      // No modal exists to fall back to.
+      await expect(modal).toHaveCount(0);
+    });
   });
 
   test.fixme('showCounter renders the cookie counter (#79)', async ({ page }) => {

--- a/playground/src/pages/index.astro
+++ b/playground/src/pages/index.astro
@@ -63,6 +63,9 @@ import Layout from '../layouts/Layout.astro';
   <div class="controls" data-cc-picker="scrim">
     <button data-val="toggle">toggle scrim</button>
   </div>
+  <div class="controls" data-cc-picker="categories-on-banner">
+    <button data-val="toggle">toggle categories on banner</button>
+  </div>
 
   <h2>Current State</h2>
   <pre id="state">No consent data yet.</pre>
@@ -226,6 +229,20 @@ import Layout from '../layouts/Layout.astro';
           const banner = document.getElementById('cc-banner');
           const current = banner?.getAttribute('data-cc-scrim') === 'true';
           applyBannerVariant(undefined, undefined, !current);
+        });
+
+      // categoriesOnBanner is resolved at injectUI time and changes the
+      // banner's structure (categories markup, dismiss button, label
+      // morphing), so we can't toggle it live — flip the URL param and let
+      // the page reload re-inject the banner with the new shape.
+      document
+        .querySelector('[data-cc-picker="categories-on-banner"]')
+        ?.addEventListener('click', () => {
+          const url = new URL(window.location.href);
+          const current = url.searchParams.get('categoriesOnBanner') === 'true';
+          if (current) url.searchParams.delete('categoriesOnBanner');
+          else url.searchParams.set('categoriesOnBanner', 'true');
+          window.location.href = url.toString();
         });
     });
   </script>


### PR DESCRIPTION
> Re-opened PR — #87 was merged into the wrong base (\`main\`). That merge was reverted on main; this PR targets \`v0.4.0\` correctly.

## Summary

- Opt-in \`ui.banner.categoriesOnBanner\` flag renders category toggles inline on the banner; the preferences modal is skipped entirely
- Banner starts collapsed; **Customize** expands it in place, action labels morph (Customize ↔ Hide preferences, Accept all ↔ Save preferences), "Reject optional" fades + collapses to zero width once expanded
- New \`×\` dismiss button hides the banner without recording consent (returns on next page load); \`showPreferences()\` flips the banner into expanded mode in single-layer

Closes #44.

## Test plan

- [x] Build (\`pnpm --filter @zdenekkurecka/astro-consent build\`) — clean
- [x] Typecheck — clean
- [x] Full e2e suite — **72 passed**, 3 pre-existing skips
- [x] New tests in \`playground/e2e/variants.spec.ts\` cover: inline render + skipped modal, Customize toggles \`data-cc-expanded\`, expanded primary saves selected toggles, collapsed primary still grants all, dismiss does not record consent, \`showPreferences()\` flips to expanded
- [ ] Visual eyeball at \`http://localhost:4321/?categoriesOnBanner=true&layout=cloud\` (and \`popup\` / \`bar\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)