### PR TITLE
feat(ui): animated dismiss confirmation + success toast (#78)

### DIFF
--- a/.changeset/dismiss-flow.md
+++ b/.changeset/dismiss-flow.md
@@ -1,0 +1,9 @@
+---
+'@zdenekkurecka/astro-consent': minor
+---
+
+Animated dismiss confirmation: after Accept / Reject / Save, the banner or modal now collapses with a per-variant animation (lift + scale + blur for bar / cloud / popup / modal, slide-to-corner for box) and a short success toast appears at the bottom-centre with the outcome headline. Honours `prefers-reduced-motion` — the collapse reduces to a 150ms opacity fade and the toast appears without its entry animation.
+
+Three new `text.*` keys customise the toast copy: `toastAccepted` (`"All cookies accepted"`), `toastRejected` (`"Only essential cookies"`), and `toastSaved` (`"Preferences saved"`). All three can also be placed inside a `localeText` entry for per-locale overrides.
+
+The toast is rendered as `<div role="status" aria-live="polite">` so assistive tech announces the outcome without stealing focus. No new events are emitted — the existing `astro-consent:consent` / `astro-consent:change` still fire at the moment the dismiss animation begins, so listeners see no added delay.

--- a/README.md
+++ b/README.md
@@ -655,6 +655,10 @@ cookieConsent({
       savePreferences: 'Save preferences',
       essentialLabel: 'Essential',
       essentialDescription: 'Required for the website to function. Cannot be disabled.',
+      // Dismiss confirmation toast (shown on accept/reject/save).
+      toastAccepted: 'All cookies accepted',
+      toastRejected: 'Only essential cookies',
+      toastSaved: 'Preferences saved',
       categories: {
         analytics: {
           label: 'Analytics',
@@ -672,6 +676,9 @@ cookieConsent({
       savePreferences: 'Uložit předvolby',
       essentialLabel: 'Nezbytné',
       essentialDescription: 'Nutné pro fungování webu. Nelze vypnout.',
+      toastAccepted: 'Přijato vše',
+      toastRejected: 'Pouze nezbytné',
+      toastSaved: 'Předvolby uloženy',
       categories: {
         analytics: {
           label: 'Analytické',
@@ -1085,6 +1092,11 @@ window.astroConsent?.reset();
 Both are typed `CustomEvent`s on `document`, so in TypeScript you get full
 autocompletion on `e.detail.categories`.
 
+The dismiss-confirmation animation and success toast (accept / reject /
+save) are purely visual — no dedicated event is emitted for them. React to
+`astro-consent:consent` / `astro-consent:change` as usual; they fire at the
+same moment the dismiss animation starts so listeners see no extra delay.
+
 ### Typed category keys
 
 By default `e.detail.categories` is typed as `Record<string, boolean>` — usable,
@@ -1138,9 +1150,15 @@ if you don't declare it, and the narrow type kicks in the moment you do.
   `aria-disabled="true"` on the locked essential category). `Space` and
   `Enter` flip them; focus rings follow `:focus-visible`.
 - Respects `prefers-reduced-motion: reduce` — the banner/modal fade, the
-  switch thumb transition, the overlay fade, and the single-layer
-  expand/collapse + reject-button collapse are all dropped when the user
-  has opted into reduced motion.
+  switch thumb transition, the overlay fade, the single-layer
+  expand/collapse + reject-button collapse, and the dismiss-confirmation
+  collapse are all reduced when the user has opted into reduced motion.
+  The per-variant collapse keyframe drops to a plain 150ms opacity fade
+  and the success toast appears without its entry animation.
+- The dismiss-confirmation toast is a `role="status"` region with
+  `aria-live="polite"`, so screen readers announce the outcome headline
+  (e.g. "Preferences saved") after an accept/reject/save without stealing
+  focus.
 - All buttons have `type="button"` so they never submit ambient forms.
 - In single-layer mode (`ui.banner.categoriesOnBanner: true`), the banner
   retains `role="dialog"` only when paired with the `popup` layout (the

--- a/packages/astro-consent/src/client.ts
+++ b/packages/astro-consent/src/client.ts
@@ -34,6 +34,9 @@ import {
   isBannerExpanded,
   setBannerExpanded,
   handleModalTabTrap,
+  dismissBannerWithConfirm,
+  dismissModalWithConfirm,
+  type DismissKind,
 } from './ui.js';
 import { activateBlockedResources, initScriptBlocker } from './scripts.js';
 import { buildGcmUpdatePayload } from './gcm.js';
@@ -197,7 +200,7 @@ export function initConsentManager(config: SerializableConsentConfig): void {
             log(`save-preferences (banner) →`, selections, isUpdate ? '(update)' : '(initial)');
             const state = savePreferences(config, selections);
             persist(state);
-            hideBanner();
+            if (!dismissBannerWithConfirm(text, 'saved')) hideBanner();
             consentFiredThisSession = true;
             emit(isUpdate ? CHANGE_EVENT : CONSENT_EVENT, state);
             break;
@@ -206,8 +209,19 @@ export function initConsentManager(config: SerializableConsentConfig): void {
           const isUpdate = !needsConsent(config.version, config.maxAgeDays);
           const state = acceptAll(config);
           persist(state);
-          hideBanner();
-          hideModal();
+          // "Accepted" via the banner vs modal routes to different surfaces.
+          // The guard is idempotent: if the surface isn't visible (e.g. the
+          // modal button was clicked while the banner was showing), the
+          // call returns false and the other path hides that surface
+          // instantly — a no-op if it was already hidden.
+          const kind: DismissKind = 'accepted';
+          if (action === 'modal-accept-all') {
+            if (!dismissModalWithConfirm(text, kind)) hideModal();
+            hideBanner();
+          } else {
+            if (!dismissBannerWithConfirm(text, kind)) hideBanner();
+            hideModal();
+          }
           consentFiredThisSession = true;
           emit(isUpdate ? CHANGE_EVENT : CONSENT_EVENT, state);
           break;
@@ -219,8 +233,14 @@ export function initConsentManager(config: SerializableConsentConfig): void {
           const isUpdate = !needsConsent(config.version, config.maxAgeDays);
           const state = rejectAll(config);
           persist(state);
-          hideBanner();
-          hideModal();
+          const kind: DismissKind = 'rejected';
+          if (action === 'modal-reject-all') {
+            if (!dismissModalWithConfirm(text, kind)) hideModal();
+            hideBanner();
+          } else {
+            if (!dismissBannerWithConfirm(text, kind)) hideBanner();
+            hideModal();
+          }
           consentFiredThisSession = true;
           emit(isUpdate ? CHANGE_EVENT : CONSENT_EVENT, state);
           break;
@@ -258,7 +278,7 @@ export function initConsentManager(config: SerializableConsentConfig): void {
           log(`save-preferences →`, selections, isUpdate ? '(update)' : '(initial)');
           const state = savePreferences(config, selections);
           persist(state);
-          hideModal();
+          if (!dismissModalWithConfirm(text, 'saved')) hideModal();
           consentFiredThisSession = true;
           emit(isUpdate ? CHANGE_EVENT : CONSENT_EVENT, state);
           break;

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -740,11 +740,146 @@
   outline-offset: 2px;
 }
 
-/* ── Reduced motion ─────────────────────────────────────
- * Strips the surface fade/slide and the switch thumb animation so users
- * with `prefers-reduced-motion: reduce` don't see the added motion.
+/* ── Dismiss confirmation ──────────────────────────────────
+ *
+ * Two-stage state machine (see `ui.ts → runDismiss`):
+ *   1. `cc-confirming` lands immediately on accept/reject/save → disables
+ *      pointer interaction so a second click can't fire mid-animation.
+ *   2. `cc-confirmed` lands ~220ms later → plays a per-variant collapse
+ *      keyframe. JS clears the classes on `animationend`.
+ *
+ * Keyframes are all prefixed `cc-dismiss-` so the state machine's
+ * `startsWith('cc-dismiss-')` guard picks them up uniformly.
  */
 
+.cc-banner.cc-confirming,
+.cc-modal.cc-confirming {
+  pointer-events: none;
+}
+
+/* Lift → scale down → blur fade-out. Used for bar, cloud, and modal. */
+@keyframes cc-dismiss-lift {
+  0%   { opacity: 1; transform: translateY(0)     scale(1);    filter: blur(0); }
+  60%  { opacity: 1; transform: translateY(-8px)  scale(0.96); filter: blur(0); }
+  100% { opacity: 0; transform: translateY(24px)  scale(0.92); filter: blur(4px); }
+}
+
+/* Popup variant — identical motion, but preserves the centered
+ * `translate(-50%, -50%)` so the collapse stays anchored to viewport centre. */
+@keyframes cc-dismiss-popup {
+  0%   { opacity: 1; transform: translate(-50%, -50%)               scale(1);    filter: blur(0); }
+  60%  { opacity: 1; transform: translate(-50%, calc(-50% - 8px))   scale(0.96); filter: blur(0); }
+  100% { opacity: 0; transform: translate(-50%, calc(-50% + 24px))  scale(0.92); filter: blur(4px); }
+}
+
+/* Box corner card — slide out along the entry axis to the nearest side. */
+@keyframes cc-dismiss-slide-right {
+  0%   { opacity: 1; transform: translateX(0);    filter: blur(0); }
+  100% { opacity: 0; transform: translateX(48px); filter: blur(4px); }
+}
+@keyframes cc-dismiss-slide-left {
+  0%   { opacity: 1; transform: translateX(0);     filter: blur(0); }
+  100% { opacity: 0; transform: translateX(-48px); filter: blur(4px); }
+}
+
+/* Reduced-motion fallback — a plain opacity fade. Must still be a keyframe
+ * animation (not `opacity: 0` set directly) so `animationend` fires and the
+ * dismiss state machine settles. */
+@keyframes cc-dismiss-fade {
+  0%   { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+.cc-banner[data-cc-layout='bar'].cc-confirmed,
+.cc-banner[data-cc-layout='cloud'].cc-confirmed,
+.cc-modal.cc-confirmed {
+  animation: cc-dismiss-lift 0.5s cubic-bezier(0.5, 0, 0.2, 1) forwards;
+}
+
+.cc-banner[data-cc-layout='popup'].cc-confirmed {
+  animation: cc-dismiss-popup 0.5s cubic-bezier(0.5, 0, 0.2, 1) forwards;
+}
+
+.cc-banner[data-cc-layout='box'][data-cc-position='bottom-right'].cc-confirmed,
+.cc-banner[data-cc-layout='box'][data-cc-position='top-right'].cc-confirmed {
+  animation: cc-dismiss-slide-right 0.5s cubic-bezier(0.5, 0, 0.2, 1) forwards;
+}
+.cc-banner[data-cc-layout='box'][data-cc-position='bottom-left'].cc-confirmed,
+.cc-banner[data-cc-layout='box'][data-cc-position='top-left'].cc-confirmed {
+  animation: cc-dismiss-slide-left 0.5s cubic-bezier(0.5, 0, 0.2, 1) forwards;
+}
+
+/* ── Success toast ─────────────────────────────────────────
+ *
+ * Fixed bottom-centre pill announced to assistive tech via
+ * `role="status"` + `aria-live="polite"`. Auto-dismisses via a chained CSS
+ * animation (0.5s in → 2.1s hold → 0.4s out) — no JS timer, `ui.ts` only
+ * removes the node on the out-animation's `animationend`.
+ */
+.cc-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 1.5rem;
+  z-index: 10002;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 1rem 0.625rem 0.625rem;
+  border-radius: var(--cc-radius-pill);
+  background:
+    radial-gradient(100% 80% at 10% 100%, var(--cc-aura-2) 0%, transparent 60%),
+    linear-gradient(180deg, var(--cc-surface-2), var(--cc-surface-3));
+  border: 1px solid var(--cc-stroke-2);
+  box-shadow: var(--cc-shadow-card);
+  backdrop-filter: blur(16px) saturate(1.2);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
+  font-family: var(--cc-font-family);
+  font-size: 0.8125rem;
+  color: var(--cc-text);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 40px);
+  animation:
+    cc-toast-in 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) forwards,
+    cc-toast-out 0.4s ease-in 2.6s forwards;
+}
+
+@keyframes cc-toast-in {
+  0%   { opacity: 0; transform: translate(-50%, 40px) scale(0.9); }
+  100% { opacity: 1; transform: translate(-50%, 0)    scale(1);   }
+}
+@keyframes cc-toast-out {
+  0%   { opacity: 1; transform: translate(-50%, 0)    scale(1);    }
+  100% { opacity: 0; transform: translate(-50%, -8px) scale(0.96); }
+}
+
+.cc-toast-check {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background: var(--cc-primary);
+  color: var(--cc-accent-ink);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.cc-toast-check svg {
+  width: 0.75rem;
+  height: 0.75rem;
+}
+.cc-toast-title {
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+/* ── Reduced motion ─────────────────────────────────────
+ * Strips surface fade-ins and the switch thumb motion for users with
+ * `prefers-reduced-motion: reduce`. Dismiss animations collapse to a plain
+ * 150ms opacity fade so `animationend` still fires and the state machine
+ * settles. Toast loses its entry animation but keeps the auto-dismiss so
+ * the node still cleans itself up.
+ */
 @media (prefers-reduced-motion: reduce) {
   .cc-banner,
   .cc-overlay,
@@ -753,7 +888,19 @@
   .cc-switch,
   .cc-switch::after {
     transition: none !important;
+  }
+  .cc-switch,
+  .cc-switch::after {
     animation: none !important;
+  }
+  .cc-banner.cc-confirmed,
+  .cc-modal.cc-confirmed {
+    animation: cc-dismiss-fade 0.15s linear forwards !important;
+  }
+  .cc-toast {
+    opacity: 1;
+    transform: translate(-50%, 0);
+    animation: cc-toast-out 0.4s linear 2.6s forwards !important;
   }
 }
 

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -230,6 +230,14 @@ export interface ConsentText<K extends string = string> {
   /** ARIA label on the banner's close (×) button. Default `"Dismiss"`. */
   dismissAriaLabel?: string;
 
+  // Dismiss confirmation toast (shown on accept / reject / save).
+  /** Toast headline after Accept all. Default `"All cookies accepted"`. */
+  toastAccepted?: string;
+  /** Toast headline after Reject all. Default `"Only essential cookies"`. */
+  toastRejected?: string;
+  /** Toast headline after Save preferences. Default `"Preferences saved"`. */
+  toastSaved?: string;
+
   // Essential category
   essentialLabel?: string;
   essentialDescription?: string;

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -32,6 +32,9 @@ const BUILT_IN_DEFAULTS: ResolvedConsentText = {
   essentialBadge: 'Required',
   badgeRequired: 'Required',
   badgeOptional: 'Optional',
+  toastAccepted: 'All cookies accepted',
+  toastRejected: 'Only essential cookies',
+  toastSaved: 'Preferences saved',
   categories: {},
 };
 
@@ -68,6 +71,9 @@ function mergeText(base: ResolvedConsentText, layer: ConsentText | undefined): R
   }
   if (layer.badgeRequired !== undefined) next.badgeRequired = layer.badgeRequired;
   if (layer.badgeOptional !== undefined) next.badgeOptional = layer.badgeOptional;
+  if (layer.toastAccepted !== undefined) next.toastAccepted = layer.toastAccepted;
+  if (layer.toastRejected !== undefined) next.toastRejected = layer.toastRejected;
+  if (layer.toastSaved !== undefined) next.toastSaved = layer.toastSaved;
 
   if (layer.categories) {
     for (const [key, override] of Object.entries(layer.categories)) {
@@ -155,6 +161,25 @@ const MODAL_TITLE_ID = 'cc-modal-title';
 const OVERLAY_ID = 'cc-overlay';
 const BANNER_ID = 'cc-banner';
 const BANNER_SCRIM_ID = 'cc-banner-scrim';
+const TOAST_TESTID = 'cc-toast';
+
+/** What the user just did — drives the toast headline. */
+export type DismissKind = 'accepted' | 'rejected' | 'saved';
+
+/**
+ * Delay from `cc-confirming` to `cc-confirmed` — matches the prototype's
+ * 220ms lead-in so the scrim has time to start fading before the card
+ * collapses. See `docs/design/consent-v0.4-prototype.html:904`.
+ */
+const CONFIRM_LEAD_IN_MS = 220;
+
+/**
+ * Fallback cap covering the longest collapse keyframe (500ms) + a small
+ * buffer. Only consulted if `animationend` never fires (e.g. the surface is
+ * removed mid-animation, or keyframes were overridden away). Keeps the
+ * `isDismissing` guard from latching on.
+ */
+const DISMISS_FALLBACK_MS = 900;
 
 const VALID_LAYOUTS: readonly BannerLayout[] = ['bar', 'box', 'cloud', 'popup'];
 const VALID_POSITIONS_PER_LAYOUT: Record<BannerLayout, readonly BannerPosition[]> = {
@@ -512,6 +537,151 @@ export function hideBanner(): void {
   el?.setAttribute('aria-hidden', 'true');
   const scrim = document.getElementById(BANNER_SCRIM_ID);
   scrim?.classList.remove('cc-visible');
+}
+
+// Module-level latch that swallows repeat accept/reject/save clicks while a
+// dismiss animation is mid-flight. Mirrors the prototype's `isConfirming`
+// guard (`docs/design/consent-v0.4-prototype.html:863`).
+let isDismissing = false;
+
+/**
+ * Build + inject the success toast. Idempotent: any in-flight toast is
+ * removed first so a rapid re-show doesn't stack DOM nodes. The toast runs
+ * its entry + auto-dismiss animations in CSS; the JS here only wires the
+ * `animationend` cleanup so the node leaves the DOM once the out-animation
+ * completes.
+ */
+function spawnToast(title: string): void {
+  for (const stale of document.querySelectorAll(`[data-testid="${TOAST_TESTID}"]`)) {
+    stale.remove();
+  }
+  const toast = document.createElement('div');
+  toast.className = 'cc-toast cc-visible';
+  toast.setAttribute('data-testid', TOAST_TESTID);
+  toast.setAttribute('role', 'status');
+  toast.setAttribute('aria-live', 'polite');
+  toast.innerHTML =
+    `<span class="cc-toast-check" aria-hidden="true">` +
+    `<svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 6.5l2.5 2.5 4.5-5"/></svg>` +
+    `</span>` +
+    `<span class="cc-toast-title">${escapeHtml(title)}</span>`;
+  document.body.appendChild(toast);
+
+  // Remove on the out-animation's end. We listen for `cc-toast-out`
+  // specifically because the element plays both `cc-toast-in` and
+  // `cc-toast-out` in sequence — removing on the first `animationend` would
+  // drop the node before the user sees it.
+  const cleanup = (e: AnimationEvent): void => {
+    if (e.animationName !== 'cc-toast-out') return;
+    toast.removeEventListener('animationend', cleanup);
+    toast.remove();
+  };
+  toast.addEventListener('animationend', cleanup);
+}
+
+/**
+ * Shared dismiss state machine used by banner and modal. Stages:
+ *   1. Immediately add `cc-confirming` → disables pointer events so a second
+ *      click can't land. Drop scrim/overlay `cc-visible` so they fade out.
+ *   2. After CONFIRM_LEAD_IN_MS, add `cc-confirmed` (plays collapse keyframe)
+ *      and spawn the toast.
+ *   3. On the collapse keyframe's `animationend`, strip `cc-visible` +
+ *      `cc-confirming` + `cc-confirmed`, set `aria-hidden="true"`, release
+ *      the `isDismissing` latch.
+ *
+ * A fallback timer releases the latch even if `animationend` never fires
+ * (e.g. the element is removed mid-animation, or keyframes were overridden).
+ */
+function runDismiss(
+  surface: HTMLElement,
+  companion: HTMLElement | null,
+  toastTitle: string,
+): void {
+  surface.classList.add('cc-confirming');
+  companion?.classList.remove('cc-visible');
+  companion?.setAttribute('aria-hidden', 'true');
+
+  let settled = false;
+  const settle = (): void => {
+    if (settled) return;
+    settled = true;
+    surface.removeEventListener('animationend', onCollapseEnd);
+    window.clearTimeout(fallback);
+    surface.classList.remove('cc-visible', 'cc-confirming', 'cc-confirmed');
+    surface.setAttribute('aria-hidden', 'true');
+    isDismissing = false;
+  };
+  const onCollapseEnd = (e: AnimationEvent): void => {
+    // Multiple animations may emit animationend (e.g. if the surface has a
+    // keyframe chain, or a descendant — like the scrim — finishes its own
+    // transition). Scope to the `cc-dismiss-*` family on the surface itself
+    // so we don't settle early on unrelated animations.
+    if (e.target !== surface) return;
+    if (!e.animationName.startsWith('cc-dismiss-')) return;
+    settle();
+  };
+  const fallback = window.setTimeout(settle, DISMISS_FALLBACK_MS);
+  surface.addEventListener('animationend', onCollapseEnd);
+
+  window.setTimeout(() => {
+    surface.classList.add('cc-confirmed');
+    spawnToast(toastTitle);
+  }, CONFIRM_LEAD_IN_MS);
+}
+
+function toastTitleFor(text: ResolvedConsentText, kind: DismissKind): string {
+  return kind === 'accepted'
+    ? text.toastAccepted
+    : kind === 'rejected'
+      ? text.toastRejected
+      : text.toastSaved;
+}
+
+/**
+ * Animate the banner away and show the confirmation toast. Guarded so a
+ * double-click during the animation is ignored. Returns `false` if the
+ * banner isn't currently visible (caller should fall back to `hideBanner`)
+ * or a dismiss is already in flight.
+ */
+export function dismissBannerWithConfirm(
+  text: ResolvedConsentText,
+  kind: DismissKind,
+): boolean {
+  if (isDismissing) return false;
+  const banner = document.getElementById(BANNER_ID);
+  if (!banner || !banner.classList.contains('cc-visible')) return false;
+  isDismissing = true;
+  const scrim = document.getElementById(BANNER_SCRIM_ID);
+  runDismiss(banner, scrim, toastTitleFor(text, kind));
+  return true;
+}
+
+/**
+ * Animate the modal away and show the confirmation toast. See
+ * `dismissBannerWithConfirm` for the state machine and guard semantics.
+ */
+export function dismissModalWithConfirm(
+  text: ResolvedConsentText,
+  kind: DismissKind,
+): boolean {
+  if (isDismissing) return false;
+  const modal = document.getElementById(MODAL_ID);
+  if (!modal || !modal.classList.contains('cc-visible')) return false;
+  isDismissing = true;
+  const overlay = document.getElementById(OVERLAY_ID);
+  // Restore focus now (same contract as hideModal) so assistive tech lands
+  // on the trigger while the collapse animation plays.
+  const toFocus = previouslyFocused;
+  previouslyFocused = null;
+  if (toFocus && toFocus.isConnected) {
+    try {
+      toFocus.focus();
+    } catch {
+      /* ignore — e.g. element became non-focusable */
+    }
+  }
+  runDismiss(modal, overlay, toastTitleFor(text, kind));
+  return true;
 }
 
 /**

--- a/playground/e2e/dismiss.spec.ts
+++ b/playground/e2e/dismiss.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test';
+import {
+  expectBannerVisible,
+  expectModalVisible,
+  openBanner,
+  sel,
+} from './helpers';
+
+/**
+ * Dismiss confirmation flow (#78). Accept / Reject / Save animate the
+ * banner or modal out and spawn a short success toast instead of snapping
+ * the surface hidden.
+ *
+ * These specs assert user-visible behaviour — toast headline, animation
+ * class progression, double-click guard — rather than exact timings.
+ * Playwright's auto-waiting retries the class / visibility asserts for
+ * up to 5s, which comfortably spans the 220ms lead-in + 500ms collapse.
+ *
+ * The toast shows the action headline only; a detail line (cookie count)
+ * will be reintroduced in v0.5 once the library knows individual cookies
+ * per category — the current "number of granted categories" is vanity
+ * and was deliberately removed.
+ */
+test.describe('Dismiss confirmation', () => {
+  test('accept-all: banner collapses and toast announces "All cookies accepted"', async ({
+    page,
+  }) => {
+    const { banner, accept } = await openBanner(page);
+
+    await accept.click();
+
+    // Stage 1: `cc-confirming` lands immediately on click, blocking further
+    // interaction. `cc-visible` stays on until the animation finishes.
+    await expect(banner).toHaveClass(/cc-confirming/);
+
+    // Toast appears with the configured headline.
+    const toast = page.locator(sel.toast());
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText('All cookies accepted');
+
+    // Banner eventually drops `cc-visible` and returns to aria-hidden.
+    await expectBannerVisible(page, false);
+  });
+
+  test('reject-all: toast reads "Only essential cookies"', async ({ page }) => {
+    const { reject } = await openBanner(page);
+
+    await reject.click();
+
+    const toast = page.locator(sel.toast());
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText('Only essential cookies');
+  });
+
+  test('save-preferences (modal): toast reads "Preferences saved"', async ({
+    page,
+  }) => {
+    const { manage, save } = await openBanner(page);
+    await manage.click();
+    await expectModalVisible(page, true);
+
+    // Flip analytics on, leave marketing off.
+    await page.locator(sel.toggleLabel('analytics')).click();
+    await save.click();
+
+    const toast = page.locator(sel.toast());
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText('Preferences saved');
+
+    await expectModalVisible(page, false);
+  });
+
+  test('single-layer save: accept-all while expanded shows "Preferences saved"', async ({
+    page,
+  }) => {
+    const { banner, manage, accept } = await openBanner(page, {
+      categoriesOnBanner: true,
+      layout: 'cloud',
+    });
+    await manage.click(); // expand
+    await banner.locator(sel.toggleLabel('analytics')).click();
+    await accept.click(); // primary morphs to Save preferences
+
+    const toast = page.locator(sel.toast());
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText('Preferences saved');
+
+    await expectBannerVisible(page, false);
+  });
+
+  test('double-click during confirm is ignored (guard)', async ({ page }) => {
+    const { accept } = await openBanner(page);
+
+    // Two rapid clicks; the second must not spawn a second toast or re-run
+    // the animation. `force` + `noWaitAfter` bypass actionability checks so
+    // the second click fires even though `cc-confirming` disables pointer
+    // events — mirrors a racing real-world double-click.
+    await accept.click();
+    await accept.click({ force: true, noWaitAfter: true });
+
+    const toasts = page.locator(sel.toast());
+    await expect(toasts).toHaveCount(1);
+  });
+
+  test('toast auto-dismisses within ~3.5s', async ({ page }) => {
+    const { accept } = await openBanner(page);
+    await accept.click();
+
+    const toast = page.locator(sel.toast());
+    await expect(toast).toBeVisible();
+    // 0.5s in + 2.1s hold + 0.4s out = 3s; give a small buffer.
+    await expect(toast).toHaveCount(0, { timeout: 4000 });
+  });
+
+  test('prefers-reduced-motion: dismiss still settles and toast still appears', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ reducedMotion: 'reduce' });
+    const page = await context.newPage();
+    try {
+      const { accept } = await openBanner(page);
+      await accept.click();
+
+      // Reduced-motion replaces the collapse with a 150ms fade, but the
+      // state machine still runs — `cc-confirming` lands and the banner
+      // ultimately hides.
+      await expect(page.locator(sel.toast())).toBeVisible();
+      await expectBannerVisible(page, false);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/playground/src/layouts/Layout.astro
+++ b/playground/src/layouts/Layout.astro
@@ -21,6 +21,12 @@ const { title } = Astro.props;
         max-width: 48rem;
         margin: 0 auto;
         padding: 2rem;
+        /* The bar / cloud banners are `position: fixed; bottom: 0` and cover
+         * the viewport's bottom edge. Without extra scroll runway the
+         * layout-picker buttons end up under the banner and clicks are
+         * intercepted. Adding ~18rem of trailing space lets the user scroll
+         * any control out from under the banner. */
+        padding-bottom: 18rem;
         color: #1a1a1a;
         line-height: 1.6;
       }


### PR DESCRIPTION
## Summary

- Two-stage dismiss animation on accept / reject / save — `cc-confirming` disables pointer events immediately, then `cc-confirmed` plays a per-variant collapse keyframe (lift+scale+blur for bar/cloud/popup/modal, slide-to-corner for box).
- Success toast (`<div role="status" aria-live="polite">`) with the outcome headline. CSS-only auto-dismiss; double-click is guarded by a module-level latch.
- `prefers-reduced-motion` fallback — 150ms opacity fade plus toast without entry animation; `animationend` still fires so the state machine settles.
- Three new `text.*` keys — `toastAccepted`, `toastRejected`, `toastSaved` — with `localeText` parity.
- Cookie-count detail line was removed vs. the original issue spec; the granted-category count duplicates what the user already saw on the toggles. Re-introduction with real per-cookie data is tracked in #90 (v0.5). Follow-up UI (#91) targets v1.0. Issue #78 updated with the scope change.
- Side fix on the playground: added `padding-bottom` to `<body>` so the layout-picker buttons can be scrolled out from under the fixed bar banner.

Closes #78.

## Test plan

- [x] `pnpm test` — 79 pass, 3 pre-existing skips
- [x] `pnpm --filter @zdenekkurecka/astro-consent build` — clean
- [x] Manual: click Accept / Reject / Save on each banner variant (bar, box, cloud, popup) and confirm the per-variant collapse + toast
- [x] Manual: `prefers-reduced-motion` on → confirm the plain fade + toast without entry animation
- [x] Manual: rapid double-click on Accept → second click is swallowed, only one toast spawns
- [x] Manual: click layout-picker buttons on the playground after scrolling them into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)