### PR TITLE
fix(gcm): escape </script> in default snippet JSON (#72)

### DIFF
--- a/.changeset/gcm-script-escape.md
+++ b/.changeset/gcm-script-escape.md
@@ -1,0 +1,5 @@
+---
+'@zdenekkurecka/astro-consent': patch
+---
+
+GCM default snippet now escapes `</` in serialized JSON, preventing early termination of the inline `<script>` if an integration-author-supplied value (e.g. a `regions` key) contains the literal `</script>` sequence. Inputs come from `astro.config.*` rather than end users, so the risk is low — but inline-script escaping is the right default for defense-in-depth.

--- a/packages/astro-consent/src/gcm.ts
+++ b/packages/astro-consent/src/gcm.ts
@@ -151,7 +151,7 @@ export function buildGcmDefaultSnippet(gcm: GoogleConsentModeConfig<string>): st
   const lines: string[] = [
     'window.dataLayer = window.dataLayer || [];',
     'function gtag(){dataLayer.push(arguments);}',
-    `gtag('consent','default',${JSON.stringify({ ...baseDefaults, wait_for_update: waitForUpdate })});`,
+    `gtag('consent','default',${safeStringify({ ...baseDefaults, wait_for_update: waitForUpdate })});`,
   ];
 
   if (gcm.regions) {
@@ -167,7 +167,7 @@ export function buildGcmDefaultSnippet(gcm: GoogleConsentModeConfig<string>): st
         }
       }
       lines.push(
-        `gtag('consent','default',${JSON.stringify({ ...regionDefaults, region: [region] })});`,
+        `gtag('consent','default',${safeStringify({ ...regionDefaults, region: [region] })});`,
       );
     }
   }
@@ -180,6 +180,16 @@ export function buildGcmDefaultSnippet(gcm: GoogleConsentModeConfig<string>): st
   }
 
   return lines.join('\n');
+}
+
+/**
+ * Serialize a payload for embedding inside an inline `<script>`. `JSON.stringify`
+ * does not escape `</`, so an integration-author-supplied value containing
+ * `</script>` would otherwise terminate the surrounding tag. Inputs here are
+ * authored in `astro.config.*` (not end-user input), so this is defense-in-depth.
+ */
+function safeStringify(obj: unknown): string {
+  return JSON.stringify(obj).replace(/<\//g, '<\\/');
 }
 
 /**

--- a/playground/e2e/gcm.spec.ts
+++ b/playground/e2e/gcm.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { clearConsent, sel } from './helpers';
+import { buildGcmDefaultSnippet } from '../../packages/astro-consent/src/gcm.js';
 
 /**
  * Collect every entry in `window.dataLayer`, normalizing the `arguments`-shaped
@@ -132,5 +133,20 @@ test.describe('Google Consent Mode v2', () => {
       analytics_storage: 'granted',
       ad_storage: 'granted',
     });
+  });
+});
+
+test.describe('buildGcmDefaultSnippet escaping (#72)', () => {
+  test('escapes </script> in region keys so inline tag cannot be terminated', () => {
+    const snippet = buildGcmDefaultSnippet({
+      mapping: { analytics: ['analytics_storage'] },
+      regions: { 'US-CA</script><script>alert(1)</script>': 'granted' },
+    });
+
+    // HTML's "script data end tag open state" triggers on `</` followed by an
+    // ASCII letter — escaping any `</` sequence is sufficient to keep the
+    // surrounding inline `<script>` tag from terminating early.
+    expect(snippet).not.toContain('</');
+    expect(snippet).toContain('<\\/script>');
   });
 });


### PR DESCRIPTION
Closes #72.

## Summary
- `buildGcmDefaultSnippet` now serializes payloads through a `safeStringify` helper that escapes `</` → `<\/`, so an integration-author-supplied value (e.g. a `regions` key containing `</script>`) cannot terminate the surrounding inline `<script>` tag.
- Inputs here are authored in `astro.config.*`, not end-user input, so the practical risk is low — but inline-script escaping is the right default for defense-in-depth.
- Adds a regression test in `playground/e2e/gcm.spec.ts` that passes an adversarial region key through `buildGcmDefaultSnippet` and asserts the output contains no `</` sequence.
- Patch changeset.

## Test plan
- [x] `pnpm test` — 80 pass, 3 pre-existing skips
- [x] New test `buildGcmDefaultSnippet escaping (#72)` passes
- [x] Existing GCM specs still pass (6 pre-existing specs)
- [x] `pnpm --filter @zdenekkurecka/astro-consent build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
