### PR TITLE
docs(adr): add Architecture Decision Records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# Working in this repo
+
+## Architecture Decision Records
+
+The `docs/adr/` folder holds the "why" behind load-bearing choices — see
+[`docs/adr/README.md`](./docs/adr/README.md) for format and conventions.
+
+When making a change, consider whether an ADR is warranted:
+
+- **Yes** if the change introduces or reverses a decision about the public
+  contract (config shape, events, runtime surface), security posture (CSP,
+  storage, cross-origin), or integration shape (Astro hooks, virtual
+  modules, peer-dep range). Examples that would need one: switching the
+  consent store, changing the event model, adding a second tag-vendor
+  integration alongside Google Consent Mode.
+- **No** for bug fixes, refactors that preserve behaviour, styling, UI
+  copy, documentation, or dependency bumps that don't shift the contract.
+
+### Workflow
+
+1. Before implementing, draft an ADR from
+   [`docs/adr/template.md`](./docs/adr/template.md) and open it as
+   `Proposed`. The draft is the design doc — it's cheaper to change minds
+   on a markdown file than on merged code.
+2. Use the next free number in sequence (`NNNN-kebab-title.md`).
+3. Keep it short — Context, Decision, Consequences, References is enough.
+   Cite file paths with line numbers, not prose descriptions of "where".
+4. Flip status to `Accepted` when the implementing PR merges. If a later
+   decision replaces it, set status to `Superseded by NNNN` and link both
+   ways.
+5. Add the new entry to the index table in
+   [`docs/adr/README.md`](./docs/adr/README.md).
+
+### AI-drafted ADRs
+
+If you draft an ADR by scanning the codebase, flag it clearly and pass it
+through a human review that answers the question: *did we actually choose
+this, or did it just happen?* Don't lock accidents in as architecture.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,21 +1,18 @@
 # 0001. Record architecture decisions
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-04-21
 
 ## Context
 
-The "why" behind astro-consent's shape is currently scattered across source
-comments, the README, CHANGELOG entries, and individual Changeset files. This
-has worked while the library is small and had effectively one maintainer, but
-it's already painful for contributors and adopters trying to answer questions
-like: *why does the runtime ship as hashed external assets instead of inline
-scripts?*, *why isn't there a callback-based API?*, *why doesn't revocation
-unload trackers?*
+The rationale behind astro-consent's shape currently lives in source
+comments, the README, CHANGELOG entries, and individual Changeset files.
+That's workable while the surface area is small, but the "why" behind
+load-bearing choices — CSP strategy, event vs. callback API, revocation
+model — is hard to find and easy to lose in refactors.
 
-A single source of truth for load-bearing decisions — one that survives
-refactors and code moves — keeps institutional knowledge from leaking out
-with turnover.
+A single place for these decisions, separate from the code that implements
+them, keeps the reasoning discoverable after the files move.
 
 ## Decision
 

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,48 @@
+# 0001. Record architecture decisions
+
+- **Status:** Accepted
+- **Date:** 2026-04-21
+
+## Context
+
+The "why" behind astro-consent's shape is currently scattered across source
+comments, the README, CHANGELOG entries, and individual Changeset files. This
+has worked while the library is small and had effectively one maintainer, but
+it's already painful for contributors and adopters trying to answer questions
+like: *why does the runtime ship as hashed external assets instead of inline
+scripts?*, *why isn't there a callback-based API?*, *why doesn't revocation
+unload trackers?*
+
+A single source of truth for load-bearing decisions — one that survives
+refactors and code moves — keeps institutional knowledge from leaking out
+with turnover.
+
+## Decision
+
+We will keep lightweight
+[Architecture Decision Records](https://adr.github.io/) in
+[`docs/adr/`](./README.md), one per file, numbered sequentially. Format:
+Context / Decision / Consequences / References — see
+[`template.md`](./template.md).
+
+Scope is restricted to decisions that touch the library's public contract,
+security posture, or integration shape. Bug fixes, refactors, and stylistic
+choices stay out.
+
+AI agents may draft ADRs from the codebase, but a human reviewer signs off
+before any record moves from `Proposed` to `Accepted`.
+
+## Consequences
+
+- **Positive:** New contributors (and future-us) can answer "why is this
+  like this?" without archaeology. Changeset entries can reference ADRs
+  instead of re-explaining rationale.
+- **Positive:** Writing an ADR surfaces cases where the current code is an
+  accident rather than a decision — useful prompts for cleanup.
+- **Negative:** Light ongoing overhead per PR that changes something
+  architectural. Mitigated by keeping the format short.
+
+## References
+
+- [Michael Nygard — Documenting Architecture Decisions](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+- [Adolfi.dev — AI generated ADRs](https://adolfi.dev/blog/ai-generated-adr/)

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,6 +1,6 @@
 # 0001. Record architecture decisions
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-21
 
 ## Context

--- a/docs/adr/0002-declarative-script-blocking.md
+++ b/docs/adr/0002-declarative-script-blocking.md
@@ -1,6 +1,6 @@
 # 0002. Declarative script blocking via `type="text/plain"`
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-21
 
 ## Context
@@ -51,7 +51,9 @@ and the component are interchangeable.
   [ADR 0008](./0008-no-teardown-on-revocation.md)).
 - **Negative:** Inline script bodies (no `data-cc-src`) require
   `'unsafe-inline'` or a CSP nonce once activated. We document this and
-  prefer the external form.
+  prefer the external form. The related CSP tension around the GCM v2
+  head-inline snippet is tracked separately in
+  [ADR 0010](./0010-csp-options-for-gcm-snippet.md).
 - **Neutral:** `data-cc-category` is also used on `[role="switch"]` elements
   inside the banner/modal; the script selector is scoped with
   `script[type="text/plain"]` and `iframe[...]:not([src])` to avoid
@@ -74,3 +76,5 @@ and the component are interchangeable.
 - `packages/astro-consent/src/components/ConsentScript.astro`
 - [ADR 0004 — Strict-CSP safety](./0004-strict-csp-safety.md)
 - [ADR 0008 — No teardown on revocation](./0008-no-teardown-on-revocation.md)
+- [ADR 0010 — CSP options for the GCM v2 snippet](./0010-csp-options-for-gcm-snippet.md)
+  (related CSP story for the one permitted inline script)

--- a/docs/adr/0002-declarative-script-blocking.md
+++ b/docs/adr/0002-declarative-script-blocking.md
@@ -1,0 +1,76 @@
+# 0002. Declarative script blocking via `type="text/plain"`
+
+- **Status:** Accepted
+- **Date:** 2026-04-21
+
+## Context
+
+Third-party tags (analytics, ads, embeds) must not execute before the user
+grants the matching consent category. Adopters drop these as `<script>` tags
+inside Astro components, partials, CMS content, and MDX — a pattern the
+library can't control or rewrite.
+
+We need a gating mechanism that:
+
+1. Works with any tracker that takes a `<script>` tag — no per-vendor glue.
+2. Is inert in the HTML until we explicitly activate it (no race where the
+   browser fetches the tracker before our gate runs).
+3. Survives SSR and static output — the gating state must be visible in the
+   markup, not assembled at runtime.
+4. Handles SPA-style navigation (Astro View Transitions) and ad-hoc DOM
+   insertion.
+5. Plays nicely with strict CSP (see [ADR 0004](./0004-strict-csp-safety.md)).
+
+## Decision
+
+Gate scripts and iframes with a declarative marker the browser already treats
+as inert, then swap them for live elements once consent is granted.
+
+- `<script type="text/plain" data-cc-category="<key>" data-cc-src="<url>">` —
+  the browser does not execute a non-JS MIME type, so the script never runs
+  until we replace it with a fresh `<script>` and copy `data-cc-src` into
+  `src`.
+- `<iframe data-cc-category="<key>" data-cc-src="<url>">` with no `src` —
+  the browser does not load a `src`-less iframe.
+- Activation copies `nonce` via the `.nonce` IDL property (not
+  `getAttribute`), since CSP L3 hides the content attribute post-parse.
+- A `MutationObserver` rooted at `document.documentElement` activates
+  matching elements inserted after the initial scan.
+
+The [`<ConsentScript>`](../../packages/astro-consent/src/components/ConsentScript.astro)
+Astro component is sugar that emits exactly this markup, so hand-written tags
+and the component are interchangeable.
+
+## Consequences
+
+- **Positive:** Vendor-agnostic — any `<script>`-based tracker slots in.
+- **Positive:** SSR/static friendly — the gate is part of the rendered HTML.
+- **Positive:** Zero-JS path when consent is already granted: a single DOM
+  scan at `astro-consent:consent` time is all that's needed.
+- **Negative:** Activation is one-way within the page (see
+  [ADR 0008](./0008-no-teardown-on-revocation.md)).
+- **Negative:** Inline script bodies (no `data-cc-src`) require
+  `'unsafe-inline'` or a CSP nonce once activated. We document this and
+  prefer the external form.
+- **Neutral:** `data-cc-category` is also used on `[role="switch"]` elements
+  inside the banner/modal; the script selector is scoped with
+  `script[type="text/plain"]` and `iframe[...]:not([src])` to avoid
+  collision.
+
+## Alternatives considered
+
+- **Runtime injection via `document.createElement('script')`.** Requires
+  adopters to move tracker snippets into JS modules and import them
+  conditionally — a significant change to established patterns and a
+  blocker for CMS/MDX-authored trackers.
+- **Fetch interception / service worker.** Over-complicated for the problem;
+  wouldn't cover inline scripts.
+- **Server-side filtering.** Works for SSR but not for static output and
+  leaks the adopter's tracker list to the server.
+
+## References
+
+- `packages/astro-consent/src/scripts.ts:1-154`
+- `packages/astro-consent/src/components/ConsentScript.astro`
+- [ADR 0004 — Strict-CSP safety](./0004-strict-csp-safety.md)
+- [ADR 0008 — No teardown on revocation](./0008-no-teardown-on-revocation.md)

--- a/docs/adr/0002-declarative-script-blocking.md
+++ b/docs/adr/0002-declarative-script-blocking.md
@@ -1,6 +1,6 @@
 # 0002. Declarative script blocking via `type="text/plain"`
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-04-21
 
 ## Context
@@ -57,16 +57,16 @@ and the component are interchangeable.
   `script[type="text/plain"]` and `iframe[...]:not([src])` to avoid
   collision.
 
-## Alternatives considered
+## Why not other shapes
 
-- **Runtime injection via `document.createElement('script')`.** Requires
+- **Runtime injection via `document.createElement('script')`.** Would force
   adopters to move tracker snippets into JS modules and import them
   conditionally — a significant change to established patterns and a
-  blocker for CMS/MDX-authored trackers.
-- **Fetch interception / service worker.** Over-complicated for the problem;
-  wouldn't cover inline scripts.
-- **Server-side filtering.** Works for SSR but not for static output and
-  leaks the adopter's tracker list to the server.
+  non-starter for CMS/MDX-authored trackers.
+- **Fetch interception / service worker.** Wouldn't cover inline scripts,
+  and adds a whole registration lifecycle for a markup-level problem.
+- **Server-side filtering.** Works for SSR but not for static output, and
+  would require the server to know the adopter's tracker list.
 
 ## References
 

--- a/docs/adr/0003-event-based-consent-api.md
+++ b/docs/adr/0003-event-based-consent-api.md
@@ -1,6 +1,6 @@
 # 0003. Event-based consent API on `document`
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-04-21
 
 ## Context
@@ -44,20 +44,21 @@ from the package entrypoint so TypeScript users can import them.
 - **Positive:** The library's own subsystems (script blocker, GCM bridge)
   consume the same events, so there's one integration point rather than
   two code paths.
-- **Negative:** Subscribers added *after* the initial `astro-consent:consent`
-  fires will miss it. Documented; adopters can fall back to
-  `window.astroConsent.get()`.
+- **Negative:** Subscribers registered *after* the initial
+  `astro-consent:consent` has fired will miss it. Adopters can poll the
+  current state via `window.astroConsent.get()` as a fallback.
 - **Negative:** The "once per session" guarantee for
   `astro-consent:consent` is managed by a module-level
   `consentFiredThisSession` flag, which must be respected by any new code
   path that emits (see [ADR 0006](./0006-view-transitions-dual-init.md)).
 
-## Alternatives considered
+## Why not other shapes
 
-- **Serialized callbacks in the config.** Closure loss (see Context).
-- **A global `window.astroConsent.on(...)` bus.** Equivalent semantics but
-  reinvents DOM events; chose events for discoverability in DevTools and
-  compatibility with existing `addEventListener` tooling.
+- **Serialized callbacks in the config.** Closure loss (see Context) —
+  the common use case of "call this imported function" doesn't survive.
+- **A bespoke `window.astroConsent.on(...)` pub/sub.** Equivalent
+  semantics to DOM events, but `addEventListener` is already the
+  lingua-franca for this pattern and shows up in DevTools out of the box.
 
 ## References
 

--- a/docs/adr/0003-event-based-consent-api.md
+++ b/docs/adr/0003-event-based-consent-api.md
@@ -1,6 +1,6 @@
 # 0003. Event-based consent API on `document`
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-21
 
 ## Context

--- a/docs/adr/0003-event-based-consent-api.md
+++ b/docs/adr/0003-event-based-consent-api.md
@@ -1,0 +1,66 @@
+# 0003. Event-based consent API on `document`
+
+- **Status:** Accepted
+- **Date:** 2026-04-21
+
+## Context
+
+Adopters need a hook for custom behaviour on consent decisions — e.g. load a
+tracker that needs a JS bootstrap, push a custom dataLayer event, toggle UI
+state. The integration config is authored in `astro.config.*`, which runs at
+build time, so anything passed there must survive serialization into a
+virtual module.
+
+Functions do not survive that round-trip in any useful way:
+`Function.prototype.toString` produces source that can be re-parsed, but the
+resulting closure has no access to the caller's module scope, imports, or
+outer state. This rules out a callback-style API
+(`cookieConsent({ onConsent: (state) => loadAnalytics() })`) for anything
+but trivial cases.
+
+## Decision
+
+Expose the consent lifecycle as `CustomEvent`s dispatched on `document`:
+
+- `astro-consent:consent` — fires once per page-load session once consent is
+  present (either freshly granted or already stored). `detail` is the full
+  `ConsentState`.
+- `astro-consent:change` — fires on every subsequent update after the
+  initial consent.
+
+Adopters subscribe from normal `<script>` tags (or modules), where closures,
+imports, and framework-specific APIs are all available.
+
+The event names are exported as `CONSENT_EVENT` / `CHANGE_EVENT` constants
+from the package entrypoint so TypeScript users can import them.
+
+## Consequences
+
+- **Positive:** Subscribers keep full module scope — the use case that
+  motivates a callback API works natively.
+- **Positive:** Decouples the runtime from the build-time config: the
+  runtime only needs to dispatch an event, not own a serialized callback
+  list.
+- **Positive:** The library's own subsystems (script blocker, GCM bridge)
+  consume the same events, so there's one integration point rather than
+  two code paths.
+- **Negative:** Subscribers added *after* the initial `astro-consent:consent`
+  fires will miss it. Documented; adopters can fall back to
+  `window.astroConsent.get()`.
+- **Negative:** The "once per session" guarantee for
+  `astro-consent:consent` is managed by a module-level
+  `consentFiredThisSession` flag, which must be respected by any new code
+  path that emits (see [ADR 0006](./0006-view-transitions-dual-init.md)).
+
+## Alternatives considered
+
+- **Serialized callbacks in the config.** Closure loss (see Context).
+- **A global `window.astroConsent.on(...)` bus.** Equivalent semantics but
+  reinvents DOM events; chose events for discoverability in DevTools and
+  compatibility with existing `addEventListener` tooling.
+
+## References
+
+- `packages/astro-consent/src/client.ts:60-73` (emit helper with rationale)
+- `packages/astro-consent/src/types.ts:390-409` (event-name constants)
+- README §"Event-based hook (advanced / full control)"

--- a/docs/adr/0004-strict-csp-safety.md
+++ b/docs/adr/0004-strict-csp-safety.md
@@ -1,0 +1,57 @@
+# 0004. Strict-CSP safety via hashed assets
+
+- **Status:** Accepted
+- **Date:** 2026-04-21
+
+## Context
+
+A non-trivial share of astro-consent's target adopters run a strict
+`script-src` CSP — often the reason they're adding a consent manager in the
+first place. Shipping an inline `<script>` or `<style>` forces them to add
+`'unsafe-inline'`, a hash, or a nonce for *our* code, which is both a
+maintenance burden and a regression in their security posture.
+
+Astro provides two injection hooks we can use:
+
+- `injectScript('page', <code>)` — bundled with the page entry, emitted as a
+  hashed `<script type="module" src="...">`.
+- `injectScript('page-ssr', <code>)` — runs during SSR; used for
+  `import "...css"` to flow through Astro's CSS extraction as a hashed
+  `<link rel="stylesheet">`.
+- `injectScript('head-inline', <code>)` — emits a raw inline `<script>` at
+  the top of `<head>`. Not CSP-friendly without an allowlist.
+
+## Decision
+
+Ship all library-owned runtime as hashed external assets:
+
+- CSS via `injectScript('page-ssr', 'import "@.../styles/base.css";')`.
+- Client runtime via `injectScript('page', 'import "virtual:astro-consent/init";')`
+  — the virtual module ([ADR 0009](./0009-virtual-module-config.md))
+  produces a real module that Vite emits as a hashed script.
+
+There is exactly **one** permitted exception: the Google Consent Mode v2
+default-denied snippet, which must run before any downstream `gtag.js` or
+GTM bootstrap and therefore can't be deferred behind a bundled entry. It is
+emitted via `injectScript('head-inline', ...)` and only when GCM is enabled
+(see [ADR 0005](./0005-google-consent-mode-v2.md)).
+
+## Consequences
+
+- **Positive:** Strict `script-src 'self'` (no `'unsafe-inline'`, no
+  per-deploy hashes or nonces for the library) works out of the box for the
+  common case.
+- **Positive:** No inline `<style>` — styles are subject to the same CSP
+  protection as any other asset.
+- **Negative:** Adopters who enable GCM on a nonce-only CSP need to either
+  add the snippet's hash or provide a nonce. Documented as a CSP caveat.
+- **Negative:** All config that reaches the client must be JSON-serializable
+  (see [ADR 0009](./0009-virtual-module-config.md)). Functions as config
+  values are impossible.
+
+## References
+
+- `packages/astro-consent/src/integration.ts:56-75`
+- README §"CSP strategy"
+- [ADR 0005 — Google Consent Mode v2](./0005-google-consent-mode-v2.md)
+- [ADR 0009 — Virtual module for config](./0009-virtual-module-config.md)

--- a/docs/adr/0004-strict-csp-safety.md
+++ b/docs/adr/0004-strict-csp-safety.md
@@ -1,6 +1,6 @@
 # 0004. Strict-CSP safety via hashed assets
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-21
 
 ## Context
@@ -43,15 +43,24 @@ emitted via `injectScript('head-inline', ...)` and only when GCM is enabled
   common case.
 - **Positive:** No inline `<style>` — styles are subject to the same CSP
   protection as any other asset.
-- **Negative:** Adopters who enable GCM on a nonce-only CSP need to either
-  add the snippet's hash or provide a nonce. Documented as a CSP caveat.
-- **Negative:** All config that reaches the client must be JSON-serializable
-  (see [ADR 0009](./0009-virtual-module-config.md)). Functions as config
-  values are impossible.
+- **Negative:** Adopters who enable GCM on a strict CSP pay the cost of
+  the one inline exception — either allowlisting a hash or supplying a
+  nonce. Mitigation is tracked in
+  [ADR 0010](./0010-csp-options-for-gcm-snippet.md) (publish the snippet
+  hash + `googleConsentMode.headInline: false` opt-out); scoped only to
+  the `GCM-enabled × nonce-only-CSP` intersection.
+- **Neutral:** Config reaching the client must be JSON-serializable
+  (see [ADR 0009](./0009-virtual-module-config.md)). The current config
+  surface is all data — numbers, strings, plain objects — so this binds
+  trivially, and behaviour (callbacks, custom hooks) goes through the
+  event model in [ADR 0003](./0003-event-based-consent-api.md), which is
+  the right shape for that regardless.
 
 ## References
 
 - `packages/astro-consent/src/integration.ts:56-75`
 - README §"CSP strategy"
+- [ADR 0003 — Event-based consent API](./0003-event-based-consent-api.md)
 - [ADR 0005 — Google Consent Mode v2](./0005-google-consent-mode-v2.md)
 - [ADR 0009 — Virtual module for config](./0009-virtual-module-config.md)
+- [ADR 0010 — CSP options for the GCM v2 snippet](./0010-csp-options-for-gcm-snippet.md)

--- a/docs/adr/0004-strict-csp-safety.md
+++ b/docs/adr/0004-strict-csp-safety.md
@@ -45,10 +45,10 @@ emitted via `injectScript('head-inline', ...)` and only when GCM is enabled
   protection as any other asset.
 - **Negative:** Adopters who enable GCM on a strict CSP pay the cost of
   the one inline exception — either allowlisting a hash or supplying a
-  nonce. Mitigation is tracked in
-  [ADR 0010](./0010-csp-options-for-gcm-snippet.md) (publish the snippet
-  hash + `googleConsentMode.headInline: false` opt-out); scoped only to
-  the `GCM-enabled × nonce-only-CSP` intersection.
+  nonce. Mitigation is the single `googleConsentMode.headInline: false`
+  opt-out proposed in
+  [ADR 0010](./0010-csp-options-for-gcm-snippet.md); scoped only to the
+  `GCM-enabled × strict-CSP` intersection.
 - **Neutral:** Config reaching the client must be JSON-serializable
   (see [ADR 0009](./0009-virtual-module-config.md)). The current config
   surface is all data — numbers, strings, plain objects — so this binds

--- a/docs/adr/0004-strict-csp-safety.md
+++ b/docs/adr/0004-strict-csp-safety.md
@@ -1,15 +1,15 @@
 # 0004. Strict-CSP safety via hashed assets
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-04-21
 
 ## Context
 
-A non-trivial share of astro-consent's target adopters run a strict
-`script-src` CSP — often the reason they're adding a consent manager in the
-first place. Shipping an inline `<script>` or `<style>` forces them to add
-`'unsafe-inline'`, a hash, or a nonce for *our* code, which is both a
-maintenance burden and a regression in their security posture.
+Strict `script-src` CSP is a common deployment posture for the kind of
+site that cares about consent in the first place. Shipping an inline
+`<script>` or `<style>` from the library forces adopters to allow
+`'unsafe-inline'`, add a hash, or plumb a nonce through for *our* code —
+all real costs they'd pay per deploy.
 
 Astro provides two injection hooks we can use:
 

--- a/docs/adr/0005-google-consent-mode-v2.md
+++ b/docs/adr/0005-google-consent-mode-v2.md
@@ -1,6 +1,6 @@
 # 0005. Google Consent Mode v2 as a first-class opt-in
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-21
 
 ## Context
@@ -28,15 +28,18 @@ Ship GCM v2 as an opt-in integration surface on the config
   the site ships.
 - An **inline default-denied snippet** is emitted at the top of `<head>` via
   `injectScript('head-inline', …)` so `gtag('consent', 'default', …)` runs
-  before any downstream gtag/GTM bootstrap (see
-  [ADR 0004](./0004-strict-csp-safety.md) for the CSP trade-off this
-  carries).
+  before any downstream gtag/GTM bootstrap. This is the single permitted
+  inline exception to [ADR 0004](./0004-strict-csp-safety.md); mitigation
+  options for adopters on strict CSP are tracked in
+  [ADR 0010](./0010-csp-options-for-gcm-snippet.md).
 - On every `astro-consent:consent` / `astro-consent:change`, the client
   emits `gtag('consent', 'update', <payload>)` with **AND semantics**: a
   signal is `granted` only when *every* category mapped to it is granted.
-- If `gtag` is missing (CSP stripped the snippet, custom head template),
-  the runtime falls back to pushing onto `dataLayer` so a later-loading
-  GTM still picks up the update.
+- If `gtag` is missing — CSP stripped the snippet, custom head template,
+  or the adopter deliberately opted out via the `headInline: false` path
+  proposed in [ADR 0010](./0010-csp-options-for-gcm-snippet.md) — the
+  runtime falls back to pushing onto `dataLayer` so a later-loading GTM
+  still picks up the update.
 
 ## Consequences
 
@@ -45,7 +48,9 @@ Ship GCM v2 as an opt-in integration surface on the config
 - **Positive:** Build-time validation prevents typos in signal names from
   silently reaching `gtag`.
 - **Negative:** Adds the one permitted inline script (see
-  [ADR 0004](./0004-strict-csp-safety.md)).
+  [ADR 0004](./0004-strict-csp-safety.md)). Adopters on strict CSP have
+  a published-hash path and a `headInline: false` opt-out tracked in
+  [ADR 0010](./0010-csp-options-for-gcm-snippet.md).
 - **Negative:** Couples astro-consent to Google-specific terminology.
   Mitigated by making the whole block opt-in and orthogonal to the core
   category model.
@@ -61,3 +66,5 @@ Ship GCM v2 as an opt-in integration surface on the config
 - `packages/astro-consent/src/client.ts:100-125` (runtime bridge + dataLayer
   fallback)
 - README §"Google Consent Mode v2"
+- [ADR 0004 — Strict-CSP safety](./0004-strict-csp-safety.md)
+- [ADR 0010 — CSP options for the GCM v2 snippet](./0010-csp-options-for-gcm-snippet.md)

--- a/docs/adr/0005-google-consent-mode-v2.md
+++ b/docs/adr/0005-google-consent-mode-v2.md
@@ -1,0 +1,67 @@
+# 0005. Google Consent Mode v2 as a first-class opt-in
+
+- **Status:** Accepted
+- **Date:** 2026-04-21
+
+## Context
+
+Google's tracking products (GA4, Google Ads, GTM) don't just stop loading
+when a user declines — they expect a `gtag('consent', 'default', …)` call
+*before* the tracker script runs, and a `gtag('consent', 'update', …)` on
+every change. Getting this wrong means either (a) leaky attribution when
+the default isn't set, or (b) broken GA4 reporting when the update never
+fires.
+
+Most astro-consent adopters pull in a Google tag, so the choice was either:
+
+1. Leave GCM entirely to the adopter (generic consent events only).
+2. Provide GCM v2 as a first-class, validated integration.
+
+Option 1 means every Google-tag adopter reinvents the same snippet, which
+in practice means many deployments get it wrong. Option 2 widens the
+library's scope but removes an entire category of bug reports.
+
+## Decision
+
+Ship GCM v2 as an opt-in integration surface on the config
+(`googleConsentMode: { mapping, defaults?, regions?, … }`):
+
+- A **mapping** from our category keys to GCM signal keys
+  (`ad_storage`, `analytics_storage`, …) is validated at build time —
+  unknown categories, unknown signals, and malformed defaults throw before
+  the site ships.
+- An **inline default-denied snippet** is emitted at the top of `<head>` via
+  `injectScript('head-inline', …)` so `gtag('consent', 'default', …)` runs
+  before any downstream gtag/GTM bootstrap (see
+  [ADR 0004](./0004-strict-csp-safety.md) for the CSP trade-off this
+  carries).
+- On every `astro-consent:consent` / `astro-consent:change`, the client
+  emits `gtag('consent', 'update', <payload>)` with **AND semantics**: a
+  signal is `granted` only when *every* category mapped to it is granted.
+- If `gtag` is missing (CSP stripped the snippet, custom head template),
+  the runtime falls back to pushing onto `dataLayer` so a later-loading
+  GTM still picks up the update.
+
+## Consequences
+
+- **Positive:** Adopters get correct Google behaviour by declaring a
+  category-to-signal mapping — no per-site snippet maintenance.
+- **Positive:** Build-time validation prevents typos in signal names from
+  silently reaching `gtag`.
+- **Negative:** Adds the one permitted inline script (see
+  [ADR 0004](./0004-strict-csp-safety.md)).
+- **Negative:** Couples astro-consent to Google-specific terminology.
+  Mitigated by making the whole block opt-in and orthogonal to the core
+  category model.
+- **Neutral:** The AND semantics (strictest category wins) matches how
+  Google documents the mapping and avoids accidentally granting a signal
+  via a lax category.
+
+## References
+
+- `packages/astro-consent/src/gcm.ts` (validation, default snippet,
+  update-payload builder)
+- `packages/astro-consent/src/integration.ts:69-75` (head-inline injection)
+- `packages/astro-consent/src/client.ts:100-125` (runtime bridge + dataLayer
+  fallback)
+- README §"Google Consent Mode v2"

--- a/docs/adr/0005-google-consent-mode-v2.md
+++ b/docs/adr/0005-google-consent-mode-v2.md
@@ -48,9 +48,11 @@ Ship GCM v2 as an opt-in integration surface on the config
 - **Positive:** Build-time validation prevents typos in signal names from
   silently reaching `gtag`.
 - **Negative:** Adds the one permitted inline script (see
-  [ADR 0004](./0004-strict-csp-safety.md)). Adopters on strict CSP have
-  a published-hash path and a `headInline: false` opt-out tracked in
-  [ADR 0010](./0010-csp-options-for-gcm-snippet.md).
+  [ADR 0004](./0004-strict-csp-safety.md)). Adopters on strict CSP get
+  a single escape hatch — `googleConsentMode.headInline: false` — tracked
+  in [ADR 0010](./0010-csp-options-for-gcm-snippet.md); they ship their
+  own snippet with whatever CSP credential (nonce or hash) fits their
+  setup.
 - **Negative:** Couples astro-consent to Google-specific terminology.
   Mitigated by making the whole block opt-in and orthogonal to the core
   category model.

--- a/docs/adr/0005-google-consent-mode-v2.md
+++ b/docs/adr/0005-google-consent-mode-v2.md
@@ -1,25 +1,21 @@
 # 0005. Google Consent Mode v2 as a first-class opt-in
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-04-21
 
 ## Context
 
-Google's tracking products (GA4, Google Ads, GTM) don't just stop loading
-when a user declines — they expect a `gtag('consent', 'default', …)` call
-*before* the tracker script runs, and a `gtag('consent', 'update', …)` on
-every change. Getting this wrong means either (a) leaky attribution when
-the default isn't set, or (b) broken GA4 reporting when the update never
-fires.
+Google's tracking products (GA4, Google Ads, GTM) expect a
+`gtag('consent', 'default', …)` call *before* the tracker script runs, and a
+`gtag('consent', 'update', …)` on every change. The default call has to be
+inline at the top of `<head>` for this ordering to hold.
 
-Most astro-consent adopters pull in a Google tag, so the choice was either:
-
-1. Leave GCM entirely to the adopter (generic consent events only).
-2. Provide GCM v2 as a first-class, validated integration.
-
-Option 1 means every Google-tag adopter reinvents the same snippet, which
-in practice means many deployments get it wrong. Option 2 widens the
-library's scope but removes an entire category of bug reports.
+The integration could leave this entirely to adopters — generic
+`astro-consent:consent` / `astro-consent:change` events give them enough
+rope. But the snippet is fiddly enough (ordering, signal names, default
+values, region overrides) that it's a frequent source of
+integration bugs, and GCM is common enough in the target use cases to
+justify a first-class surface that keeps the rules in one place.
 
 ## Decision
 

--- a/docs/adr/0006-view-transitions-dual-init.md
+++ b/docs/adr/0006-view-transitions-dual-init.md
@@ -1,6 +1,6 @@
 # 0006. Dual init for View Transitions and classic navigation
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-21
 
 ## Context

--- a/docs/adr/0006-view-transitions-dual-init.md
+++ b/docs/adr/0006-view-transitions-dual-init.md
@@ -1,0 +1,72 @@
+# 0006. Dual init for View Transitions and classic navigation
+
+- **Status:** Accepted
+- **Date:** 2026-04-21
+
+## Context
+
+Astro supports two navigation models:
+
+- **View Transitions enabled** — initial `DOMContentLoaded` fires once;
+  subsequent navigations swap the DOM without a new page load. Astro emits
+  `astro:page-load` on every navigation, including the first.
+- **Classic navigation** — `DOMContentLoaded` fires on every page load;
+  `astro:page-load` never fires.
+
+The consent runtime must initialize in both models. Binding only to
+`astro:page-load` breaks classic sites; binding only to `DOMContentLoaded`
+leaves the modal unmounted after a View Transitions navigation that swaps
+the banner markup out of the DOM.
+
+An additional constraint: some work (event delegation, `MutationObserver`,
+the once-per-session `astro-consent:consent` emit) must *not* repeat across
+View Transitions navigations, or handlers accumulate and the consent event
+fires on every page.
+
+## Decision
+
+The generated init module subscribes to **both** events and calls
+`initConsentManager(config)` from each handler:
+
+```js
+document.addEventListener('astro:page-load', init);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init, { once: true });
+} else {
+  init();
+}
+```
+
+`initConsentManager` is idempotent by design. Three module-level flags
+guard work that must happen at most once per page lifecycle:
+
+- `listenerAttached` — the click/keydown delegation on `document`.
+- `scriptBlockerAttached` — the `MutationObserver` and consent→activate
+  wiring.
+- `consentFiredThisSession` — whether `astro-consent:consent` has fired for
+  this page load (re-fire is disallowed; only `astro-consent:change`
+  follows).
+
+UI re-injection (`injectUI`) is itself idempotent and *does* run per
+navigation, which restores the banner/modal markup after a View Transition
+swap.
+
+## Consequences
+
+- **Positive:** One build works on both VT and non-VT sites without adopter
+  configuration.
+- **Positive:** The guards are named for the invariant they protect, making
+  the contract explicit for future maintainers.
+- **Negative:** Any new init code path must decide, deliberately, whether
+  it belongs behind one of the guards. Easy to get wrong without reading
+  the comments.
+- **Negative:** Adopters who programmatically replace `document` contents
+  outside of Astro's navigation (rare) may need to call
+  `window.astroConsent.show()` manually.
+
+## References
+
+- `packages/astro-consent/src/virtual-config.ts:35-55` (dual-event wiring
+  in the generated init module)
+- `packages/astro-consent/src/client.ts:55-58` (guard flags)
+- `packages/astro-consent/src/client.ts:143-152` (once-per-session emit)

--- a/docs/adr/0006-view-transitions-dual-init.md
+++ b/docs/adr/0006-view-transitions-dual-init.md
@@ -1,6 +1,6 @@
 # 0006. Dual init for View Transitions and classic navigation
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-04-21
 
 ## Context
@@ -60,9 +60,6 @@ swap.
 - **Negative:** Any new init code path must decide, deliberately, whether
   it belongs behind one of the guards. Easy to get wrong without reading
   the comments.
-- **Negative:** Adopters who programmatically replace `document` contents
-  outside of Astro's navigation (rare) may need to call
-  `window.astroConsent.show()` manually.
 
 ## References
 

--- a/docs/adr/0007-category-based-consent-state.md
+++ b/docs/adr/0007-category-based-consent-state.md
@@ -1,0 +1,68 @@
+# 0007. Category-based consent state with implicit `essential`
+
+- **Status:** Accepted
+- **Date:** 2026-04-21
+
+## Context
+
+GDPR and ePrivacy require per-purpose consent: users grant or deny specific
+categories (analytics, marketing, …) rather than a single global flag.
+Regulators and DPAs generally treat "strictly necessary" cookies as exempt
+from consent, but they must still be acknowledged in the UI.
+
+The library also needs to:
+
+- Let adopters define *their own* category keys — the set of meaningful
+  categories differs per site.
+- Handle policy changes (new category added, purpose of existing category
+  changed) by re-prompting users.
+- Handle time-bounded consent (some jurisdictions expect re-prompting after
+  N days) without forcing a re-prompt on every page load.
+
+## Decision
+
+Represent stored consent as:
+
+```ts
+interface ConsentState {
+  version: number;                      // matches config.version at time of save
+  timestamp: number;                    // Date.now() at save
+  categories: Record<string, boolean>;  // user-defined keys + implicit 'essential': true
+}
+```
+
+- **`essential` is always `true`.** It is added implicitly on every write
+  path (`acceptAll`, `rejectAll`, `savePreferences`, `api.set`). Adopters
+  don't declare it as a category; it's a property of the state shape.
+- **`version` is adopter-controlled.** Bumping
+  `cookieConsent({ version: N })` in `astro.config.*` invalidates stored
+  consent whose `version < N` and re-shows the banner — the re-prompt
+  lever for policy changes.
+- **`maxAgeDays` is optional.** When set, consent older than the threshold
+  is treated as missing; triggers a re-prompt without a version bump.
+- **Category keys are opaque to the library.** The recipes documentation
+  uses `analytics` and `marketing` as conventions, but nothing in the
+  runtime hard-codes them.
+
+## Consequences
+
+- **Positive:** Adopters model categories that fit their site's tracker
+  inventory.
+- **Positive:** Re-prompting is a one-line config change (`version` bump)
+  or a declarative policy (`maxAgeDays`), not a bespoke migration.
+- **Positive:** `essential: true` being non-negotiable in the stored state
+  prevents a user API call from accidentally "denying" the category — the
+  write-through always restores it.
+- **Negative:** Category keys are a stringly-typed contract. Mitigated by
+  the `ConsentCategoryKey` marker interface (see `types.ts`) that
+  adopters can augment with their typed keys.
+- **Negative:** Stored state from a future library version with additional
+  fields will be read back as the older shape on downgrade. We don't
+  currently downgrade, but a breaking-shape change needs its own ADR.
+
+## References
+
+- `packages/astro-consent/src/consent.ts:50-87` (state shape + write paths)
+- `packages/astro-consent/src/types.ts` (`ConsentState`,
+  `ConsentCategoryKey`)
+- README §"Category config" and §"Versioning & re-prompting"

--- a/docs/adr/0007-category-based-consent-state.md
+++ b/docs/adr/0007-category-based-consent-state.md
@@ -1,6 +1,6 @@
 # 0007. Category-based consent state with implicit `essential`
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-04-21
 
 ## Context
@@ -56,9 +56,6 @@ interface ConsentState {
 - **Negative:** Category keys are a stringly-typed contract. Mitigated by
   the `ConsentCategoryKey` marker interface (see `types.ts`) that
   adopters can augment with their typed keys.
-- **Negative:** Stored state from a future library version with additional
-  fields will be read back as the older shape on downgrade. We don't
-  currently downgrade, but a breaking-shape change needs its own ADR.
 
 ## References
 

--- a/docs/adr/0007-category-based-consent-state.md
+++ b/docs/adr/0007-category-based-consent-state.md
@@ -1,6 +1,6 @@
 # 0007. Category-based consent state with implicit `essential`
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-21
 
 ## Context
@@ -53,13 +53,22 @@ interface ConsentState {
 - **Positive:** `essential: true` being non-negotiable in the stored state
   prevents a user API call from accidentally "denying" the category — the
   write-through always restores it.
-- **Negative:** Category keys are a stringly-typed contract. Mitigated by
-  the `ConsentCategoryKey` marker interface (see `types.ts`) that
-  adopters can augment with their typed keys.
+- **Negative:** Category keys are a stringly-typed contract at runtime.
+  Opt-in type safety is one `.d.ts` file away: adopters augment the
+  empty `ConsentKeys` marker interface via TypeScript declaration
+  merging, and `ResolvedConsentKeys` (a conditional type) flows the
+  narrowed key union into both the `DocumentEventMap` entries for
+  `astro-consent:consent` / `astro-consent:change` *and* the
+  `window.astroConsent` API. Typos become compile errors across the
+  whole public surface; without the augmentation the keys fall back to
+  `Record<string, boolean>`, preserving the no-breakage default.
 
 ## References
 
 - `packages/astro-consent/src/consent.ts:50-87` (state shape + write paths)
-- `packages/astro-consent/src/types.ts` (`ConsentState`,
-  `ConsentCategoryKey`)
+- `packages/astro-consent/src/types.ts` — `ConsentState`
+- `packages/astro-consent/src/types.ts:411-457` — `ConsentKeys` marker
+  interface, `ResolvedConsentKeys` resolver, and the
+  `DocumentEventMap` / `Window` declaration-merging that propagates
+  typed keys across the public surface
 - README §"Category config" and §"Versioning & re-prompting"

--- a/docs/adr/0008-no-teardown-on-revocation.md
+++ b/docs/adr/0008-no-teardown-on-revocation.md
@@ -1,0 +1,59 @@
+# 0008. No teardown on revocation
+
+- **Status:** Accepted
+- **Date:** 2026-04-21
+
+## Context
+
+A consent manager must allow users to withdraw consent as easily as they
+gave it. The obvious-looking feature is: on revocation, unload the trackers
+that were activated. In practice, that's infeasible for most real
+trackers.
+
+Once activated, third-party SDKs typically:
+
+- attach persistent listeners (`beforeunload`, `pagehide`, `visibilitychange`),
+- install timers and background fetches,
+- set cookies on first-party and third-party domains,
+- augment globals (`gtag`, `fbq`, `dataLayer`, `_paq`, …) that other code
+  may already be calling,
+- load nested scripts we don't control and can't enumerate.
+
+Removing the `<script>` tag or deleting the global does not roll any of
+this back, and half-unloading produces exotic failures (e.g. listeners
+still fire but reference a now-undefined `gtag`).
+
+## Decision
+
+The library treats activation as **one-way within a page lifecycle**. Once a
+gated script or iframe flips to live, it stays live for the rest of that
+page's session.
+
+Revocation takes effect on the **next full navigation** — the stored
+consent state is updated immediately, so the next `readConsent()` returns
+the new categories, and the next page load gates the trackers correctly.
+
+Adopters who need hard revocation within the session can listen for
+`astro-consent:change` and call `location.reload()`. This is documented as
+a caveat in the README and in the recipes.
+
+## Consequences
+
+- **Positive:** Avoids the "zombie tracker" class of bugs where a
+  half-unloaded SDK keeps sending events or corrupts globals.
+- **Positive:** Implementation stays simple: activation is a one-shot
+  operation with an idempotency marker (`data-cc-activated`).
+- **Negative:** A user who revokes mid-session and doesn't navigate
+  continues to have already-activated trackers running until the next
+  page load. This is a compliance surface adopters need to understand.
+- **Neutral:** The constraint is inherited from the third-party ecosystem,
+  not from our design — a different architecture wouldn't meaningfully
+  change the outcome.
+
+## References
+
+- `packages/astro-consent/src/scripts.ts:17-21` (documented invariant)
+- `packages/astro-consent/src/scripts.ts:54-87` (`data-cc-activated`
+  marker)
+- `docs/recipes/README.md` ("A note on revocation")
+- README §"Revocation"

--- a/docs/adr/0008-no-teardown-on-revocation.md
+++ b/docs/adr/0008-no-teardown-on-revocation.md
@@ -1,6 +1,6 @@
 # 0008. No teardown on revocation
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-21
 
 ## Context
@@ -43,9 +43,19 @@ pattern per vendor.
   half-unloaded SDK keeps sending events or corrupts globals.
 - **Positive:** Implementation stays simple: activation is a one-shot
   operation with an idempotency marker (`data-cc-activated`).
-- **Negative:** A user who revokes mid-session and doesn't navigate
+- **Trade-off:** A user who revokes mid-session and doesn't navigate
   continues to have already-activated trackers running until the next
-  page load. This is a compliance surface adopters need to understand.
+  navigation. In practice the window is seconds to minutes, and GDPR
+  Art. 7(3) only guarantees lawfulness of processing *before*
+  withdrawal — not instant teardown after. The practical in-session
+  lever for adopters is the event model from
+  [ADR 0003](./0003-event-based-consent-api.md): GCM v2 `gtag('consent',
+  'update', ...)` fires automatically on `astro-consent:change` (see
+  [ADR 0005](./0005-google-consent-mode-v2.md)), and vendor-specific
+  revoke hooks like `fbq('consent', 'revoke')` are wired from the same
+  event (see `docs/recipes/meta-pixel.md:100-111`). Residual risk is
+  limited to trackers with no opt-out API, between the click and the
+  next navigation.
 - **Neutral:** The constraint is inherited from the third-party ecosystem,
   not from our design — a different architecture wouldn't meaningfully
   change the outcome.
@@ -56,5 +66,7 @@ pattern per vendor.
 - `packages/astro-consent/src/scripts.ts:54-87` (`data-cc-activated`
   marker)
 - `docs/recipes/README.md` ("A note on revocation")
-- `docs/recipes/meta-pixel.md` (vendor-driven teardown example)
+- `docs/recipes/meta-pixel.md:100-111` (vendor-driven teardown example)
 - README §"Revocation caveat" (line 474)
+- [ADR 0003 — Event-based consent API](./0003-event-based-consent-api.md)
+- [ADR 0005 — Google Consent Mode v2](./0005-google-consent-mode-v2.md)

--- a/docs/adr/0008-no-teardown-on-revocation.md
+++ b/docs/adr/0008-no-teardown-on-revocation.md
@@ -1,14 +1,14 @@
 # 0008. No teardown on revocation
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-04-21
 
 ## Context
 
-A consent manager must allow users to withdraw consent as easily as they
-gave it. The obvious-looking feature is: on revocation, unload the trackers
-that were activated. In practice, that's infeasible for most real
-trackers.
+A consent manager should let users withdraw consent as easily as they
+gave it. The obvious-looking feature is: on revocation, unload the
+trackers that were activated. In practice, that isn't feasible for most
+real-world trackers.
 
 Once activated, third-party SDKs typically:
 
@@ -20,8 +20,7 @@ Once activated, third-party SDKs typically:
 - load nested scripts we don't control and can't enumerate.
 
 Removing the `<script>` tag or deleting the global does not roll any of
-this back, and half-unloading produces exotic failures (e.g. listeners
-still fire but reference a now-undefined `gtag`).
+this back — the SDK is, for practical purposes, load-once.
 
 ## Decision
 
@@ -31,11 +30,12 @@ page's session.
 
 Revocation takes effect on the **next full navigation** — the stored
 consent state is updated immediately, so the next `readConsent()` returns
-the new categories, and the next page load gates the trackers correctly.
+the new categories and the next page load gates the trackers correctly.
 
-Adopters who need hard revocation within the session can listen for
-`astro-consent:change` and call `location.reload()`. This is documented as
-a caveat in the README and in the recipes.
+For trackers that *do* expose a teardown affordance (e.g. Meta Pixel's
+`fbq('consent', 'revoke')`), adopters drive it themselves from an
+`astro-consent:change` listener. The README and recipes document this
+pattern per vendor.
 
 ## Consequences
 
@@ -56,4 +56,5 @@ a caveat in the README and in the recipes.
 - `packages/astro-consent/src/scripts.ts:54-87` (`data-cc-activated`
   marker)
 - `docs/recipes/README.md` ("A note on revocation")
-- README §"Revocation"
+- `docs/recipes/meta-pixel.md` (vendor-driven teardown example)
+- README §"Revocation caveat" (line 474)

--- a/docs/adr/0009-virtual-module-config.md
+++ b/docs/adr/0009-virtual-module-config.md
@@ -1,6 +1,6 @@
 # 0009. Virtual module for build-to-runtime config
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-04-21
 
 ## Context
@@ -57,9 +57,8 @@ Astro emit a hashed `<script type="module" src="...">` for the whole thing.
   functions, regexes, classes. This cascades into the API design (see
   [ADR 0003](./0003-event-based-consent-api.md) for why that's actually
   the right constraint).
-- **Negative:** Ties the integration to Vite — fine today because Astro
-  *is* Vite, but an ADR to revisit if Astro ever supports alternative
-  bundlers.
+- **Neutral:** Uses Vite's virtual-module API. Astro is Vite-based today,
+  so this is a non-issue in practice.
 
 ## References
 

--- a/docs/adr/0009-virtual-module-config.md
+++ b/docs/adr/0009-virtual-module-config.md
@@ -1,0 +1,71 @@
+# 0009. Virtual module for build-to-runtime config
+
+- **Status:** Accepted
+- **Date:** 2026-04-21
+
+## Context
+
+Integration config (`cookieConsent({ version, categories, text, … })`) is
+authored in `astro.config.*`, which runs at build time in Node. The
+consent runtime, in contrast, runs in the browser and needs the same
+config as input.
+
+The bridge between the two has several viable shapes:
+
+1. **Data attribute / global.** Stamp the config as JSON into
+   `<script>window.__astroConsentConfig = …</script>`. Works but requires
+   an inline `<script>` (defeats [ADR 0004](./0004-strict-csp-safety.md)).
+2. **Public asset.** Write the serialized config to
+   `public/astro-consent-config.json` and `fetch()` it at runtime. Adds a
+   network round-trip and mutates the adopter's `public/` directory.
+3. **Module graph via Vite virtual modules.** Expose `virtual:…` specifiers
+   that resolve to synthetic modules emitted by a Vite plugin. The
+   bundler treats the config as a normal import; no inline code, no
+   extra fetches.
+
+The runtime also needs to resolve the client entry by package name so the
+emitted import strings don't bake absolute filesystem paths into the
+adopter's build.
+
+## Decision
+
+Expose two virtual modules via a Vite plugin registered from the
+integration:
+
+- `virtual:astro-consent/config` — evaluates to
+  `export default <JSON.stringify(config)>`.
+- `virtual:astro-consent/init` — a small generated module that imports the
+  config from the above, imports `initConsentManager` from
+  `@zdenekkurecka/astro-consent/client` (the package's public bare
+  specifier), and wires the dual-init events
+  (see [ADR 0006](./0006-view-transitions-dual-init.md)).
+
+The integration hook calls
+`injectScript('page', 'import "virtual:astro-consent/init";')`, letting
+Astro emit a hashed `<script type="module" src="...">` for the whole thing.
+
+## Consequences
+
+- **Positive:** No inline `<script>` for config — keeps the strict-CSP
+  story from [ADR 0004](./0004-strict-csp-safety.md) intact.
+- **Positive:** Config travels through Vite's normal module pipeline —
+  HMR, tree-shaking, and source maps all work without custom plumbing.
+- **Positive:** Importing the client by bare specifier means the runtime
+  is decoupled from the on-disk `dist/` layout of the package. Works the
+  same way in a monorepo pnpm link as in a published install.
+- **Negative:** Every config value must be JSON-serializable — no
+  functions, regexes, classes. This cascades into the API design (see
+  [ADR 0003](./0003-event-based-consent-api.md) for why that's actually
+  the right constraint).
+- **Negative:** Ties the integration to Vite — fine today because Astro
+  *is* Vite, but an ADR to revisit if Astro ever supports alternative
+  bundlers.
+
+## References
+
+- `packages/astro-consent/src/virtual-config.ts` (plugin + generated init)
+- `packages/astro-consent/src/integration.ts:49-67` (plugin registration
+  and `injectScript` call)
+- [ADR 0003 — Event-based consent API](./0003-event-based-consent-api.md)
+- [ADR 0004 — Strict-CSP safety](./0004-strict-csp-safety.md)
+- [ADR 0006 — Dual init](./0006-view-transitions-dual-init.md)

--- a/docs/adr/0009-virtual-module-config.md
+++ b/docs/adr/0009-virtual-module-config.md
@@ -1,6 +1,6 @@
 # 0009. Virtual module for build-to-runtime config
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-21
 
 ## Context

--- a/docs/adr/0010-csp-options-for-gcm-snippet.md
+++ b/docs/adr/0010-csp-options-for-gcm-snippet.md
@@ -1,4 +1,4 @@
-# 0010. CSP options for the GCM v2 head-inline snippet
+# 0010. CSP opt-out for the GCM v2 head-inline snippet
 
 - **Status:** Proposed
 - **Date:** 2026-04-21
@@ -13,70 +13,67 @@ call must run before any downstream gtag/GTM bootstrap, and nothing we
 bundle executes early enough in `<head>` to satisfy that ordering.
 
 The net effect: adopters who enable GCM *and* run a strict CSP either
-weaken their CSP (add `'unsafe-inline'` — unacceptable), allowlist a
-hash, or plumb a nonce through. Today we provide no tooling for either,
-so the CSP story in [ADR 0004](./0004-strict-csp-safety.md) effectively
-doesn't hold once GCM is turned on.
+weaken their CSP (`'unsafe-inline'` — unacceptable), allowlist a hash,
+or plumb a nonce through. Today we offer no escape hatch, so the strict
+CSP story in ADR 0004 breaks the moment GCM is enabled.
 
-The options we looked at:
+The full option space:
 
-1. **Publish the snippet's SHA-256 hash.** Adopters paste it into their
-   CSP as `'sha256-…'`.
-2. **Let adopters opt out of the head-inline.** They ship their own
+1. **Publish the snippet's SHA-256 hash** so adopters paste it into CSP.
+2. **Opt out of the head-inline** — adopter ships their own
    `gtag('consent','default',…)` with their own nonce or hash; our
-   integration keeps validating the mapping, emitting updates on
-   consent events, and falling back via `dataLayer`.
-3. **Nonce support.** Stamp a configured nonce onto the emitted inline
-   `<script>`. Leans on the adopter's SSR / middleware nonce pipeline;
-   worth revisiting alongside Astro 5's experimental CSP work.
-4. **Move the snippet to an external bundled module.** Removes the
-   inline exception entirely but risks a race where GTM loads before our
-   bundled module has executed. High blast radius across SSR streaming,
-   View Transitions, and `defer`-free ordering.
+   integration keeps validating the mapping and emitting updates via the
+   `dataLayer` fallback wired in [ADR 0005](./0005-google-consent-mode-v2.md).
+3. **Nonce support** — stamp a configured nonce onto the emitted inline
+   `<script>`. Leans on the adopter's SSR / middleware nonce pipeline.
+4. **Move the snippet external** — bundled module loaded synchronously
+   from `<head>`. Removes the inline exception entirely but opens
+   ordering races against downstream gtag/GTM. High blast radius.
 
 ## Decision
 
-Implement (1) and (2). Defer (3) and (4) to their own future ADRs if
-real-world evidence surfaces a need.
+Implement **(2) only**: one config knob,
+`googleConsentMode.headInline: boolean` (default `true`).
 
-Concretely:
+- `true` (default): unchanged from today — the inline default-denied
+  snippet is injected at the top of `<head>`. Works out of the box for
+  adopters on `'unsafe-inline'` or permissive CSP.
+- `false`: the integration skips `injectScript('head-inline', ...)`
+  entirely. Adopters ship their own `gtag('consent','default',…)` with
+  whatever CSP credential their setup requires (nonce or hash).
+  Validation, event-driven `gtag('consent','update', …)` dispatches, and
+  the `dataLayer` fallback from [ADR 0005](./0005-google-consent-mode-v2.md)
+  are unchanged, so the adopter's hand-rolled snippet composes with the
+  rest of the integration.
 
-- **Hash.** At build time, compute `SHA-256` of the emitted GCM snippet
-  and log it once (`[astro-consent] CSP hash for GCM snippet: sha256-…`)
-  so adopters can copy it into their CSP header. Also expose it
-  programmatically from the integration hook (exact shape TBD in the
-  implementing PR — options include a return value from
-  `cookieConsent()`, a `logger.info` line, or a virtual module).
-- **`headInline: false` opt-out.** Extend
-  `GoogleConsentModeConfig` with `headInline?: boolean` (default `true`).
-  When `false`, the integration skips
-  `injectScript('head-inline', ...)`. Validation, event-driven updates,
-  and the `dataLayer` fallback are unchanged — adopters get the runtime
-  bridge without the inline snippet.
-
-Nonce and bundled-module paths are explicitly **not** part of this
-decision. If an adopter asks for either, that's a new ADR with its own
-evidence.
+Hash publishing, nonce injection, and external bundling (options 1, 3,
+4) are explicitly **not** part of this decision. If a future adopter
+cohort surfaces real evidence they need any of those, each gets its own
+ADR.
 
 ## Consequences
 
-- **Positive:** Covers the two mainstream strict-CSP postures:
-  hash-based CSP (use (1)) and nonce-based CSP (use (2) and bring your
-  own snippet).
-- **Positive:** Keeps the GCM integration useful even when adopters
-  can't take our inline snippet — the validation + update bridge is
-  where most of the value lives.
-- **Positive:** Doesn't prejudge the nonce or external-bundle
-  conversations. Small surface, reversible.
-- **Negative:** Two solutions instead of one. Docs need to explain when
-  to reach for which; some adopters will pick the wrong one on first
-  try.
-- **Negative:** The hash is deterministic only if the snippet input is
-  deterministic. Any future change to `buildGcmDefaultSnippet` shifts
-  the hash — adopters have to update their CSP. This is inherent to
-  hash-based CSP; document it.
-- **Neutral:** (3) and (4) remain on the table as follow-ups if the
-  two-option set proves insufficient.
+- **Positive:** Universal escape hatch — one knob covers every strict
+  CSP posture. Nonce-CSP adopters pass their own nonce via their own
+  snippet; hash-CSP adopters hash their own snippet; anyone on
+  `'unsafe-inline'` ignores the flag entirely.
+- **Positive:** Minimal surface. One boolean in the config, one branch
+  in the integration hook, no new side outputs (no build-log hashes, no
+  nonce pipelines).
+- **Positive:** `dataLayer` fallback from ADR 0005 makes the opt-out
+  compose cleanly — `gtag('consent','update',…)` still lands even when
+  our snippet never runs.
+- **Negative:** Adopters on hash-CSP who would have liked a
+  pre-computed hash now compute their own (e.g.
+  `printf '%s' "$snippet" | openssl dgst -sha256 -binary | openssl base64`).
+  One command; adopters auditing what lands in their CSP are already
+  reading the snippet anyway.
+- **Negative:** `headInline: false` pushes responsibility onto the
+  adopter to get the default-denied snippet right. Mitigated by pointing
+  at the existing `buildGcmDefaultSnippet` output as a reference template
+  in the README.
+- **Neutral:** Options 1, 3, 4 remain on the table. Each is a future
+  ADR if the one-knob answer proves insufficient.
 
 ## References
 
@@ -84,5 +81,6 @@ evidence.
 - [ADR 0005 — Google Consent Mode v2](./0005-google-consent-mode-v2.md)
 - `packages/astro-consent/src/gcm.ts` — `buildGcmDefaultSnippet`
 - `packages/astro-consent/src/integration.ts:69-75` — the
-  `injectScript('head-inline', …)` call this ADR carves options around
+  `injectScript('head-inline', …)` call that `headInline: false` will
+  gate
 - [MDN — CSP `script-src` hashes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#hashes)

--- a/docs/adr/0010-csp-options-for-gcm-snippet.md
+++ b/docs/adr/0010-csp-options-for-gcm-snippet.md
@@ -1,0 +1,88 @@
+# 0010. CSP options for the GCM v2 head-inline snippet
+
+- **Status:** Proposed
+- **Date:** 2026-04-21
+
+## Context
+
+[ADR 0004](./0004-strict-csp-safety.md) sets the rule: no inline scripts
+from the library. [ADR 0005](./0005-google-consent-mode-v2.md) carves out
+one exception — the GCM v2 default-denied snippet is emitted via
+`injectScript('head-inline', …)` because the `gtag('consent','default',…)`
+call must run before any downstream gtag/GTM bootstrap, and nothing we
+bundle executes early enough in `<head>` to satisfy that ordering.
+
+The net effect: adopters who enable GCM *and* run a strict CSP either
+weaken their CSP (add `'unsafe-inline'` — unacceptable), allowlist a
+hash, or plumb a nonce through. Today we provide no tooling for either,
+so the CSP story in [ADR 0004](./0004-strict-csp-safety.md) effectively
+doesn't hold once GCM is turned on.
+
+The options we looked at:
+
+1. **Publish the snippet's SHA-256 hash.** Adopters paste it into their
+   CSP as `'sha256-…'`.
+2. **Let adopters opt out of the head-inline.** They ship their own
+   `gtag('consent','default',…)` with their own nonce or hash; our
+   integration keeps validating the mapping, emitting updates on
+   consent events, and falling back via `dataLayer`.
+3. **Nonce support.** Stamp a configured nonce onto the emitted inline
+   `<script>`. Leans on the adopter's SSR / middleware nonce pipeline;
+   worth revisiting alongside Astro 5's experimental CSP work.
+4. **Move the snippet to an external bundled module.** Removes the
+   inline exception entirely but risks a race where GTM loads before our
+   bundled module has executed. High blast radius across SSR streaming,
+   View Transitions, and `defer`-free ordering.
+
+## Decision
+
+Implement (1) and (2). Defer (3) and (4) to their own future ADRs if
+real-world evidence surfaces a need.
+
+Concretely:
+
+- **Hash.** At build time, compute `SHA-256` of the emitted GCM snippet
+  and log it once (`[astro-consent] CSP hash for GCM snippet: sha256-…`)
+  so adopters can copy it into their CSP header. Also expose it
+  programmatically from the integration hook (exact shape TBD in the
+  implementing PR — options include a return value from
+  `cookieConsent()`, a `logger.info` line, or a virtual module).
+- **`headInline: false` opt-out.** Extend
+  `GoogleConsentModeConfig` with `headInline?: boolean` (default `true`).
+  When `false`, the integration skips
+  `injectScript('head-inline', ...)`. Validation, event-driven updates,
+  and the `dataLayer` fallback are unchanged — adopters get the runtime
+  bridge without the inline snippet.
+
+Nonce and bundled-module paths are explicitly **not** part of this
+decision. If an adopter asks for either, that's a new ADR with its own
+evidence.
+
+## Consequences
+
+- **Positive:** Covers the two mainstream strict-CSP postures:
+  hash-based CSP (use (1)) and nonce-based CSP (use (2) and bring your
+  own snippet).
+- **Positive:** Keeps the GCM integration useful even when adopters
+  can't take our inline snippet — the validation + update bridge is
+  where most of the value lives.
+- **Positive:** Doesn't prejudge the nonce or external-bundle
+  conversations. Small surface, reversible.
+- **Negative:** Two solutions instead of one. Docs need to explain when
+  to reach for which; some adopters will pick the wrong one on first
+  try.
+- **Negative:** The hash is deterministic only if the snippet input is
+  deterministic. Any future change to `buildGcmDefaultSnippet` shifts
+  the hash — adopters have to update their CSP. This is inherent to
+  hash-based CSP; document it.
+- **Neutral:** (3) and (4) remain on the table as follow-ups if the
+  two-option set proves insufficient.
+
+## References
+
+- [ADR 0004 — Strict-CSP safety](./0004-strict-csp-safety.md)
+- [ADR 0005 — Google Consent Mode v2](./0005-google-consent-mode-v2.md)
+- `packages/astro-consent/src/gcm.ts` — `buildGcmDefaultSnippet`
+- `packages/astro-consent/src/integration.ts:69-75` — the
+  `injectScript('head-inline', …)` call this ADR carves options around
+- [MDN — CSP `script-src` hashes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#hashes)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,69 @@
+# Architecture Decision Records
+
+This folder captures the "why" behind architectural choices in astro-consent.
+Each record is a short markdown file describing one decision, its context, and
+its consequences — the
+[Nygard-style](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+lightweight ADR format.
+
+ADRs are a companion to the README and source comments, not a replacement.
+They exist because the README explains *what the library does today* while an
+ADR explains *why it ended up that way* — information that's hard to recover
+once the code has moved on.
+
+## How we use ADRs here
+
+- **One decision per file.** If you're writing "and also…" you probably have
+  two ADRs.
+- **Filename:** `NNNN-kebab-title.md` with `NNNN` a zero-padded sequence
+  number. Once assigned, never renumber — superseding ADRs gets its own new
+  number and links back.
+- **Status values:**
+  - `Proposed` — drafted, under discussion.
+  - `Accepted` — the code reflects this decision.
+  - `Superseded by NNNN` — kept for history; a newer ADR replaces it.
+  - `Deprecated` — the decision no longer applies and no replacement exists.
+- **When to write one.** Add an ADR when a PR introduces (or reverses) a
+  choice that's load-bearing for the library's public contract, security
+  posture, or integration shape — things like "how we gate scripts", "how we
+  talk to the outside world", "what we persist". Don't ADR bug fixes,
+  refactors, or style changes.
+- **Who drafts.** Anyone — including an AI agent — can draft an ADR from the
+  template. A human reviewer signs off before the status flips from
+  `Proposed` to `Accepted`.
+
+## Working with AI-drafted ADRs
+
+Inspired by [Adolfi.dev — AI-generated ADRs][adolfi]. An agent is good at
+scanning the codebase and articulating what's already there, but it can
+rationalize *accidents* as if they were deliberate *decisions*. Every
+AI-drafted ADR goes through a human pass that answers: "did we actually
+choose this, or did it just happen?" If it just happened, either make the
+real choice now or don't record it.
+
+[adolfi]: https://adolfi.dev/blog/ai-generated-adr/
+
+## Index
+
+| #    | Title                                                                                          | Status   |
+| ---- | ---------------------------------------------------------------------------------------------- | -------- |
+| 0001 | [Record architecture decisions](./0001-record-architecture-decisions.md)                       | Accepted |
+| 0002 | [Declarative script blocking via `type="text/plain"`](./0002-declarative-script-blocking.md)   | Accepted |
+| 0003 | [Event-based consent API on `document`](./0003-event-based-consent-api.md)                     | Accepted |
+| 0004 | [Strict-CSP safety via hashed assets](./0004-strict-csp-safety.md)                             | Accepted |
+| 0005 | [Google Consent Mode v2 as a first-class opt-in](./0005-google-consent-mode-v2.md)             | Accepted |
+| 0006 | [Dual init for View Transitions and classic navigation](./0006-view-transitions-dual-init.md)  | Accepted |
+| 0007 | [Category-based consent state with implicit `essential`](./0007-category-based-consent-state.md) | Accepted |
+| 0008 | [No teardown on revocation](./0008-no-teardown-on-revocation.md)                               | Accepted |
+| 0009 | [Virtual module for build-to-runtime config](./0009-virtual-module-config.md)                  | Accepted |
+
+## Candidates for future ADRs
+
+Decisions that are real but not yet written up. Add one when the topic next
+comes up for discussion:
+
+- `localStorage` (vs cookies / sessionStorage) as the consent store, with
+  `version` and `maxAgeDays`-driven re-prompt.
+- pnpm workspace + Changesets as the release flow.
+- Playwright in the playground (vs unit tests) as the test strategy.
+- ESM-only output with an `exports` map and `astro ^5 || ^6` peer range.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,7 +52,7 @@ real choice now or don't record it.
 | 0003 | [Event-based consent API on `document`](./0003-event-based-consent-api.md)                     | Accepted |
 | 0004 | [Strict-CSP safety via hashed assets](./0004-strict-csp-safety.md)                             | Accepted |
 | 0005 | [Google Consent Mode v2 as a first-class opt-in](./0005-google-consent-mode-v2.md)             | Accepted |
-| 0006 | [Dual init for View Transitions and classic navigation](./0006-view-transitions-dual-init.md)  | Proposed |
+| 0006 | [Dual init for View Transitions and classic navigation](./0006-view-transitions-dual-init.md)  | Accepted |
 | 0007 | [Category-based consent state with implicit `essential`](./0007-category-based-consent-state.md) | Proposed |
 | 0008 | [No teardown on revocation](./0008-no-teardown-on-revocation.md)                               | Proposed |
 | 0009 | [Virtual module for build-to-runtime config](./0009-virtual-module-config.md)                  | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,7 +48,7 @@ real choice now or don't record it.
 | #    | Title                                                                                          | Status   |
 | ---- | ---------------------------------------------------------------------------------------------- | -------- |
 | 0001 | [Record architecture decisions](./0001-record-architecture-decisions.md)                       | Accepted |
-| 0002 | [Declarative script blocking via `type="text/plain"`](./0002-declarative-script-blocking.md)   | Proposed |
+| 0002 | [Declarative script blocking via `type="text/plain"`](./0002-declarative-script-blocking.md)   | Accepted |
 | 0003 | [Event-based consent API on `document`](./0003-event-based-consent-api.md)                     | Proposed |
 | 0004 | [Strict-CSP safety via hashed assets](./0004-strict-csp-safety.md)                             | Proposed |
 | 0005 | [Google Consent Mode v2 as a first-class opt-in](./0005-google-consent-mode-v2.md)             | Proposed |
@@ -56,6 +56,7 @@ real choice now or don't record it.
 | 0007 | [Category-based consent state with implicit `essential`](./0007-category-based-consent-state.md) | Proposed |
 | 0008 | [No teardown on revocation](./0008-no-teardown-on-revocation.md)                               | Proposed |
 | 0009 | [Virtual module for build-to-runtime config](./0009-virtual-module-config.md)                  | Proposed |
+| 0010 | [CSP options for the GCM v2 snippet](./0010-csp-options-for-gcm-snippet.md)                    | Proposed |
 
 ## Candidates for future ADRs
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,15 +47,15 @@ real choice now or don't record it.
 
 | #    | Title                                                                                          | Status   |
 | ---- | ---------------------------------------------------------------------------------------------- | -------- |
-| 0001 | [Record architecture decisions](./0001-record-architecture-decisions.md)                       | Accepted |
-| 0002 | [Declarative script blocking via `type="text/plain"`](./0002-declarative-script-blocking.md)   | Accepted |
-| 0003 | [Event-based consent API on `document`](./0003-event-based-consent-api.md)                     | Accepted |
-| 0004 | [Strict-CSP safety via hashed assets](./0004-strict-csp-safety.md)                             | Accepted |
-| 0005 | [Google Consent Mode v2 as a first-class opt-in](./0005-google-consent-mode-v2.md)             | Accepted |
-| 0006 | [Dual init for View Transitions and classic navigation](./0006-view-transitions-dual-init.md)  | Accepted |
-| 0007 | [Category-based consent state with implicit `essential`](./0007-category-based-consent-state.md) | Accepted |
-| 0008 | [No teardown on revocation](./0008-no-teardown-on-revocation.md)                               | Accepted |
-| 0009 | [Virtual module for build-to-runtime config](./0009-virtual-module-config.md)                  | Accepted |
+| 0001 | [Record architecture decisions](./0001-record-architecture-decisions.md)                       | Proposed |
+| 0002 | [Declarative script blocking via `type="text/plain"`](./0002-declarative-script-blocking.md)   | Proposed |
+| 0003 | [Event-based consent API on `document`](./0003-event-based-consent-api.md)                     | Proposed |
+| 0004 | [Strict-CSP safety via hashed assets](./0004-strict-csp-safety.md)                             | Proposed |
+| 0005 | [Google Consent Mode v2 as a first-class opt-in](./0005-google-consent-mode-v2.md)             | Proposed |
+| 0006 | [Dual init for View Transitions and classic navigation](./0006-view-transitions-dual-init.md)  | Proposed |
+| 0007 | [Category-based consent state with implicit `essential`](./0007-category-based-consent-state.md) | Proposed |
+| 0008 | [No teardown on revocation](./0008-no-teardown-on-revocation.md)                               | Proposed |
+| 0009 | [Virtual module for build-to-runtime config](./0009-virtual-module-config.md)                  | Proposed |
 
 ## Candidates for future ADRs
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,7 +53,7 @@ real choice now or don't record it.
 | 0004 | [Strict-CSP safety via hashed assets](./0004-strict-csp-safety.md)                             | Accepted |
 | 0005 | [Google Consent Mode v2 as a first-class opt-in](./0005-google-consent-mode-v2.md)             | Accepted |
 | 0006 | [Dual init for View Transitions and classic navigation](./0006-view-transitions-dual-init.md)  | Accepted |
-| 0007 | [Category-based consent state with implicit `essential`](./0007-category-based-consent-state.md) | Proposed |
+| 0007 | [Category-based consent state with implicit `essential`](./0007-category-based-consent-state.md) | Accepted |
 | 0008 | [No teardown on revocation](./0008-no-teardown-on-revocation.md)                               | Proposed |
 | 0009 | [Virtual module for build-to-runtime config](./0009-virtual-module-config.md)                  | Proposed |
 | 0010 | [CSP options for the GCM v2 snippet](./0010-csp-options-for-gcm-snippet.md)                    | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,7 +55,7 @@ real choice now or don't record it.
 | 0006 | [Dual init for View Transitions and classic navigation](./0006-view-transitions-dual-init.md)  | Accepted |
 | 0007 | [Category-based consent state with implicit `essential`](./0007-category-based-consent-state.md) | Accepted |
 | 0008 | [No teardown on revocation](./0008-no-teardown-on-revocation.md)                               | Accepted |
-| 0009 | [Virtual module for build-to-runtime config](./0009-virtual-module-config.md)                  | Proposed |
+| 0009 | [Virtual module for build-to-runtime config](./0009-virtual-module-config.md)                  | Accepted |
 | 0010 | [CSP options for the GCM v2 snippet](./0010-csp-options-for-gcm-snippet.md)                    | Proposed |
 
 ## Candidates for future ADRs

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,7 +49,7 @@ real choice now or don't record it.
 | ---- | ---------------------------------------------------------------------------------------------- | -------- |
 | 0001 | [Record architecture decisions](./0001-record-architecture-decisions.md)                       | Accepted |
 | 0002 | [Declarative script blocking via `type="text/plain"`](./0002-declarative-script-blocking.md)   | Accepted |
-| 0003 | [Event-based consent API on `document`](./0003-event-based-consent-api.md)                     | Proposed |
+| 0003 | [Event-based consent API on `document`](./0003-event-based-consent-api.md)                     | Accepted |
 | 0004 | [Strict-CSP safety via hashed assets](./0004-strict-csp-safety.md)                             | Proposed |
 | 0005 | [Google Consent Mode v2 as a first-class opt-in](./0005-google-consent-mode-v2.md)             | Proposed |
 | 0006 | [Dual init for View Transitions and classic navigation](./0006-view-transitions-dual-init.md)  | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,7 +47,7 @@ real choice now or don't record it.
 
 | #    | Title                                                                                          | Status   |
 | ---- | ---------------------------------------------------------------------------------------------- | -------- |
-| 0001 | [Record architecture decisions](./0001-record-architecture-decisions.md)                       | Proposed |
+| 0001 | [Record architecture decisions](./0001-record-architecture-decisions.md)                       | Accepted |
 | 0002 | [Declarative script blocking via `type="text/plain"`](./0002-declarative-script-blocking.md)   | Proposed |
 | 0003 | [Event-based consent API on `document`](./0003-event-based-consent-api.md)                     | Proposed |
 | 0004 | [Strict-CSP safety via hashed assets](./0004-strict-csp-safety.md)                             | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,7 +51,7 @@ real choice now or don't record it.
 | 0002 | [Declarative script blocking via `type="text/plain"`](./0002-declarative-script-blocking.md)   | Accepted |
 | 0003 | [Event-based consent API on `document`](./0003-event-based-consent-api.md)                     | Accepted |
 | 0004 | [Strict-CSP safety via hashed assets](./0004-strict-csp-safety.md)                             | Accepted |
-| 0005 | [Google Consent Mode v2 as a first-class opt-in](./0005-google-consent-mode-v2.md)             | Proposed |
+| 0005 | [Google Consent Mode v2 as a first-class opt-in](./0005-google-consent-mode-v2.md)             | Accepted |
 | 0006 | [Dual init for View Transitions and classic navigation](./0006-view-transitions-dual-init.md)  | Proposed |
 | 0007 | [Category-based consent state with implicit `essential`](./0007-category-based-consent-state.md) | Proposed |
 | 0008 | [No teardown on revocation](./0008-no-teardown-on-revocation.md)                               | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,7 +54,7 @@ real choice now or don't record it.
 | 0005 | [Google Consent Mode v2 as a first-class opt-in](./0005-google-consent-mode-v2.md)             | Accepted |
 | 0006 | [Dual init for View Transitions and classic navigation](./0006-view-transitions-dual-init.md)  | Accepted |
 | 0007 | [Category-based consent state with implicit `essential`](./0007-category-based-consent-state.md) | Accepted |
-| 0008 | [No teardown on revocation](./0008-no-teardown-on-revocation.md)                               | Proposed |
+| 0008 | [No teardown on revocation](./0008-no-teardown-on-revocation.md)                               | Accepted |
 | 0009 | [Virtual module for build-to-runtime config](./0009-virtual-module-config.md)                  | Proposed |
 | 0010 | [CSP options for the GCM v2 snippet](./0010-csp-options-for-gcm-snippet.md)                    | Proposed |
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,7 +50,7 @@ real choice now or don't record it.
 | 0001 | [Record architecture decisions](./0001-record-architecture-decisions.md)                       | Accepted |
 | 0002 | [Declarative script blocking via `type="text/plain"`](./0002-declarative-script-blocking.md)   | Accepted |
 | 0003 | [Event-based consent API on `document`](./0003-event-based-consent-api.md)                     | Accepted |
-| 0004 | [Strict-CSP safety via hashed assets](./0004-strict-csp-safety.md)                             | Proposed |
+| 0004 | [Strict-CSP safety via hashed assets](./0004-strict-csp-safety.md)                             | Accepted |
 | 0005 | [Google Consent Mode v2 as a first-class opt-in](./0005-google-consent-mode-v2.md)             | Proposed |
 | 0006 | [Dual init for View Transitions and classic navigation](./0006-view-transitions-dual-init.md)  | Proposed |
 | 0007 | [Category-based consent state with implicit `essential`](./0007-category-based-consent-state.md) | Proposed |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,34 @@
+# NNNN. Short decision title
+
+- **Status:** Proposed | Accepted | Superseded by [NNNN](./NNNN-title.md) | Deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** @handle, @handle
+
+## Context
+
+What is the problem or forcing function? What constraints or prior decisions
+shape the space of answers? Keep this to the facts a future reader needs to
+re-derive the decision — no solutions yet.
+
+## Decision
+
+What did we decide to do? State it in the active voice ("we will …").
+
+## Consequences
+
+What becomes easier, harder, or impossible as a result? List both sides — a
+decision with no downsides probably wasn't a real choice.
+
+- **Positive:** …
+- **Negative:** …
+- **Neutral:** …
+
+## Alternatives considered
+
+Briefly, what else was on the table and why it lost. Skip if there were no
+serious contenders.
+
+## References
+
+- `path/to/file.ts:NN-MM` — where the decision is visible in the code
+- Related ADRs, issues, PRs, external links


### PR DESCRIPTION
## Summary

Introduces [`docs/adr/`](./docs/adr/) as a home for lightweight, Nygard-style Architecture Decision Records, plus a short ADR workflow in `CLAUDE.md` (when to write one, how the AI-drafted review loop works). Inspired by [adolfi.dev/blog/ai-generated-adr](https://adolfi.dev/blog/ai-generated-adr/) — the AI can scan the codebase and articulate what's there, but a human reviewer signs off before anything flips from `Proposed` to `Accepted` so we don't lock accidents in as architecture.

### ADRs included

Nine cover the load-bearing decisions already baked into the library, all reviewed and **Accepted**:

- **0001** — Record architecture decisions (meta)
- **0002** — Declarative script blocking via `type="text/plain"`
- **0003** — Event-based consent API on `document`
- **0004** — Strict-CSP safety via hashed assets
- **0005** — Google Consent Mode v2 as a first-class opt-in
- **0006** — Dual init for View Transitions and classic navigation
- **0007** — Category-based consent state with implicit `essential`
- **0008** — No teardown on revocation
- **0009** — Virtual module for build-to-runtime config

One forward-looking decision as **Proposed** (design doc for a future PR, not implemented here):

- **0010** — CSP opt-out for the GCM v2 head-inline snippet (single config knob `googleConsentMode.headInline: boolean` to escape the one inline exception carved out by 0005)

### What this PR does NOT change

Zero runtime or API changes. Only `docs/adr/` and `CLAUDE.md`. ADR 0010 proposes an implementation but this PR does not ship it.

## Test plan

- [ ] Skim the index at [`docs/adr/README.md`](./docs/adr/README.md) — every ADR listed, status matches front-matter
- [ ] Spot-check a few file:line citations still match the code (they'll rot over time; this is the baseline)
- [ ] Confirm `CLAUDE.md` workflow matches the shape you want contributors to follow
- [ ] Decide whether **0010** should merge as `Proposed` or be split into its own PR

https://claude.ai/code/session_01NSBecCrPkKrVF7UJ26FsTp