### PR TITLE
fix(ui): reserve layout space so banner no longer overlays page footer (#97)

### DIFF
--- a/.changeset/banner-layout-space.md
+++ b/.changeset/banner-layout-space.md
@@ -1,0 +1,5 @@
+---
+'@zdenekkurecka/astro-consent': patch
+---
+
+Banner now reserves real layout space at the bottom of the host page so it no longer overlays footers and bottom CTAs. The runtime measures the banner on show (and re-measures via `ResizeObserver` when it wraps on narrow viewports), publishing the size as `--cc-banner-height` on `:root`. Default zero-specificity rules consume the var as `padding-bottom` on `body` and `scroll-padding-bottom` on `:root`, both no-ops when the banner isn't visible. The padding transition matches the banner's existing 0.3s ease so the show/hide animates cleanly.

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -64,6 +64,23 @@
   --cc-border: #475569;
 }
 
+/* ── Host page spacing for the fixed banner ─────────────────
+ * The runtime sets `--cc-banner-height` on :root while the banner is
+ * visible (and clears it on dismiss). These rules consume it so the host
+ * page reserves real layout space — without them the banner overlays
+ * footers/CTAs at the bottom of the page. Wrapped in :where() for zero
+ * specificity so consumer body/root rules trivially override. The transition
+ * matches the banner's transform/opacity timing below to avoid a jolt.
+ */
+:where(body) {
+  padding-bottom: var(--cc-banner-height, 0);
+  transition: padding-bottom 0.3s ease;
+}
+
+:where(:root) {
+  scroll-padding-bottom: var(--cc-banner-height, 0);
+}
+
 /* ── Banner ─────────────────────────────────────────────── */
 
 .cc-banner {

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -140,8 +140,10 @@ const MODAL_ID = 'cc-modal';
 const MODAL_TITLE_ID = 'cc-modal-title';
 const OVERLAY_ID = 'cc-overlay';
 const BANNER_ID = 'cc-banner';
+const BANNER_HEIGHT_VAR = '--cc-banner-height';
 
 let previouslyFocused: HTMLElement | null = null;
+let bannerResizeObserver: ResizeObserver | null = null;
 
 function escapeHtml(str: string): string {
   return str
@@ -305,16 +307,41 @@ export function setContainerTheme(mode: 'auto' | 'light' | 'dark'): void {
   }
 }
 
+/**
+ * Publish the banner's measured height as `--cc-banner-height` on :root so
+ * default `:where(body) { padding-bottom: var(--cc-banner-height) }` (and
+ * `scroll-padding-bottom`) reserve real layout space for the fixed banner.
+ * Without this the host page's footer sits behind the banner.
+ */
+function updateBannerHeightVar(el: HTMLElement): void {
+  const root = document.documentElement;
+  if (!root) return;
+  root.style.setProperty(BANNER_HEIGHT_VAR, `${el.getBoundingClientRect().height}px`);
+}
+
 export function showBanner(): void {
   const el = document.getElementById(BANNER_ID);
-  el?.classList.add('cc-visible');
-  el?.setAttribute('aria-hidden', 'false');
+  if (!el) return;
+  el.classList.add('cc-visible');
+  el.setAttribute('aria-hidden', 'false');
+
+  updateBannerHeightVar(el);
+  // Re-measure on viewport resize (banner wraps on narrow widths) so the
+  // reserved space stays accurate. Feature-detected for older targets.
+  if (typeof ResizeObserver !== 'undefined' && !bannerResizeObserver) {
+    bannerResizeObserver = new ResizeObserver(() => updateBannerHeightVar(el));
+    bannerResizeObserver.observe(el);
+  }
 }
 
 export function hideBanner(): void {
   const el = document.getElementById(BANNER_ID);
   el?.classList.remove('cc-visible');
   el?.setAttribute('aria-hidden', 'true');
+
+  bannerResizeObserver?.disconnect();
+  bannerResizeObserver = null;
+  document.documentElement?.style.removeProperty(BANNER_HEIGHT_VAR);
 }
 
 /**

--- a/playground/e2e/banner.spec.ts
+++ b/playground/e2e/banner.spec.ts
@@ -30,4 +30,32 @@ test.describe('Banner', () => {
     await expect(link).toHaveAttribute('href', '/cookie-policy');
     await expect(link).toHaveText('Cookie Policy');
   });
+
+  test('publishes --cc-banner-height while visible and clears it on dismiss', async ({ page }) => {
+    await expectBannerVisible(page, true);
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() =>
+          document.documentElement.style.getPropertyValue('--cc-banner-height').trim(),
+        ),
+      )
+      .toMatch(/^\d+(\.\d+)?px$/);
+
+    const heightPx = await page.evaluate(() =>
+      parseFloat(document.documentElement.style.getPropertyValue('--cc-banner-height')),
+    );
+    expect(heightPx).toBeGreaterThan(0);
+
+    await page.locator('[data-cc=accept-all]').click();
+    await expectBannerVisible(page, false);
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() =>
+          document.documentElement.style.getPropertyValue('--cc-banner-height'),
+        ),
+      )
+      .toBe('');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #97 — the fixed banner used to overlay the host page's footer and bottom CTAs because it never pushed any space into the document flow.

- Runtime measures the banner on show and publishes the height as `--cc-banner-height` on `:root`, re-measuring via `ResizeObserver` when the banner wraps on narrow viewports. The var is cleared on hide.
- Default zero-specificity CSS rules consume the var as `padding-bottom` on `body` and `scroll-padding-bottom` on `:root`. Both no-op when the banner isn't visible, and `:where()` keeps consumer overrides trivial.
- `padding-bottom` carries a `0.3s ease` transition matching the banner's existing `transform`/`opacity` so the show/hide animates cleanly.

## Test plan

- [x] New Playwright spec asserts `--cc-banner-height` is set to a positive `px` value while the banner is visible and cleared on dismissal
- [x] Full Playwright suite (50 tests) passes locally on chromium
- [ ] Visual check on a host site with a tall footer — footer fully reachable while banner is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
