### PR TITLE
fix(a11y): pair aria-hidden with inert on banner/modal (#99)

### DIFF
--- a/.changeset/aria-hidden-inert.md
+++ b/.changeset/aria-hidden-inert.md
@@ -1,0 +1,5 @@
+---
+'@zdenekkurecka/astro-consent': patch
+---
+
+`#cc-banner` and `#cc-modal` now pair `aria-hidden` with the `inert` attribute so they no longer trip the axe `aria-hidden-focus` rule (flagged by Vercel's live accessibility audit). Previously both containers shipped with `aria-hidden="true"` but kept their action buttons / toggles in the tab order, so keyboard users could focus invisible buttons and AT-aware audits failed. `inert` is added on hide and removed on show, in lock-step with `aria-hidden`. Browsers without `inert` support fall back to the existing aria-hidden-only behavior.

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -180,7 +180,7 @@ function createPolicyLinkHTML(
 function createBannerHTML(config: SerializableConsentConfig, text: ResolvedConsentText): string {
   const policyLink = createPolicyLinkHTML(config.cookiePolicy, 'cc-policy-link');
   return `
-    <div class="cc-banner" id="${BANNER_ID}" role="region" aria-label="Cookie consent" aria-hidden="true">
+    <div class="cc-banner" id="${BANNER_ID}" role="region" aria-label="Cookie consent" aria-hidden="true" inert>
       <div class="cc-banner-inner">
         <p class="cc-banner-text">
           ${escapeHtml(text.bannerText)}
@@ -253,6 +253,7 @@ function createModalHTML(config: SerializableConsentConfig, text: ResolvedConsen
       aria-labelledby="${MODAL_TITLE_ID}"
       aria-hidden="true"
       tabindex="-1"
+      inert
     >
       <div class="cc-modal-inner">
         <div class="cc-modal-header">
@@ -324,6 +325,10 @@ export function showBanner(): void {
   if (!el) return;
   el.classList.add('cc-visible');
   el.setAttribute('aria-hidden', 'false');
+  // `inert` is paired with aria-hidden so axe `aria-hidden-focus` is
+  // satisfied when the banner is dismissed: the subtree is unfocusable AND
+  // hidden from AT, instead of just visually hidden with focusable buttons.
+  el.removeAttribute('inert');
 
   updateBannerHeightVar(el);
   // Re-measure on viewport resize (banner wraps on narrow widths) so the
@@ -338,6 +343,7 @@ export function hideBanner(): void {
   const el = document.getElementById(BANNER_ID);
   el?.classList.remove('cc-visible');
   el?.setAttribute('aria-hidden', 'true');
+  el?.setAttribute('inert', '');
 
   bannerResizeObserver?.disconnect();
   bannerResizeObserver = null;
@@ -417,6 +423,9 @@ export function showModal(): void {
 
   modal.classList.add('cc-visible');
   modal.setAttribute('aria-hidden', 'false');
+  // Drop `inert` before the focus dance below — inert blocks programmatic
+  // focus too, so leaving it on would break the requestAnimationFrame focus.
+  modal.removeAttribute('inert');
   if (overlay) {
     overlay.classList.add('cc-visible');
     overlay.setAttribute('aria-hidden', 'false');
@@ -438,6 +447,7 @@ export function hideModal(): void {
   if (modal) {
     modal.classList.remove('cc-visible');
     modal.setAttribute('aria-hidden', 'true');
+    modal.setAttribute('inert', '');
   }
   if (overlay) {
     overlay.classList.remove('cc-visible');

--- a/playground/e2e/banner.spec.ts
+++ b/playground/e2e/banner.spec.ts
@@ -31,6 +31,25 @@ test.describe('Banner', () => {
     await expect(link).toHaveText('Cookie Policy');
   });
 
+  test('toggles `inert` alongside aria-hidden so axe `aria-hidden-focus` passes', async ({
+    page,
+  }) => {
+    const banner = page.locator('#cc-banner');
+    await expectBannerVisible(page, true);
+    await expect(banner).not.toHaveAttribute('inert', /.*/);
+
+    await page.locator('[data-cc=accept-all]').click();
+    await expectBannerVisible(page, false);
+    await expect(banner).toHaveAttribute('inert', /.*/);
+
+    const acceptFocusable = await page.evaluate(() => {
+      const btn = document.querySelector<HTMLElement>('[data-cc=accept-all]');
+      btn?.focus();
+      return document.activeElement === btn;
+    });
+    expect(acceptFocusable).toBe(false);
+  });
+
   test('publishes --cc-banner-height while visible and clears it on dismiss', async ({ page }) => {
     await expectBannerVisible(page, true);
 

--- a/playground/e2e/modal.spec.ts
+++ b/playground/e2e/modal.spec.ts
@@ -54,6 +54,21 @@ test.describe('Preferences modal', () => {
     await expect(modal).toHaveAttribute('aria-labelledby', 'cc-modal-title');
   });
 
+  test('toggles `inert` alongside aria-hidden so axe `aria-hidden-focus` passes', async ({
+    page,
+  }) => {
+    const modal = page.locator('#cc-modal');
+    await expect(modal).toHaveAttribute('inert', /.*/);
+
+    await page.locator('[data-cc=manage]').click();
+    await expectModalVisible(page, true);
+    await expect(modal).not.toHaveAttribute('inert', /.*/);
+
+    await page.keyboard.press('Escape');
+    await expectModalVisible(page, false);
+    await expect(modal).toHaveAttribute('inert', /.*/);
+  });
+
   test('modal accept-all works same as banner accept-all', async ({ page }) => {
     await page.locator('[data-cc=manage]').click();
     await page.locator('[data-cc=modal-accept-all]').click();


### PR DESCRIPTION
## Summary

Fixes #99 — surfaced by a consumer's Vercel live accessibility audit.

`#cc-banner` and `#cc-modal` shipped with `aria-hidden="true"` initially and after dismissal but still contained focusable buttons/toggles, so:

- axe `aria-hidden-focus` failed on every audit
- Sighted keyboard users could tab into invisible controls

Now `inert` is paired with `aria-hidden` in lock-step on both containers — added on hide, removed on show. The modal removes `inert` before its `requestAnimationFrame` focus dance so programmatic focus still lands. Browsers without `inert` support (very old Safari/FF) ignore the attribute → graceful degradation.

## Test plan

- [x] New Playwright spec on `#cc-banner` asserts `inert` toggling around show/dismiss and verifies the accept-all button cannot receive focus when hidden
- [x] New Playwright spec on `#cc-modal` asserts `inert` is present initially, removed on open, re-added on close
- [x] Full Playwright suite (52 tests) passes locally on chromium
- [ ] Re-run consumer's Vercel live a11y audit — `aria-hidden-focus` no longer flags either container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
