### PR TITLE
release: v0.3.1 (banner layout space + a11y inert)

### DIFF
--- a/.changeset/aria-hidden-inert.md
+++ b/.changeset/aria-hidden-inert.md
@@ -1,0 +1,5 @@
+---
+'@zdenekkurecka/astro-consent': patch
+---
+
+`#cc-banner` and `#cc-modal` now pair `aria-hidden` with the `inert` attribute so they no longer trip the axe `aria-hidden-focus` rule (flagged by Vercel's live accessibility audit). Previously both containers shipped with `aria-hidden="true"` but kept their action buttons / toggles in the tab order, so keyboard users could focus invisible buttons and AT-aware audits failed. `inert` is added on hide and removed on show, in lock-step with `aria-hidden`. Browsers without `inert` support fall back to the existing aria-hidden-only behavior.

--- a/.changeset/banner-layout-space.md
+++ b/.changeset/banner-layout-space.md
@@ -1,0 +1,5 @@
+---
+'@zdenekkurecka/astro-consent': patch
+---
+
+Banner now reserves real layout space at the bottom of the host page so it no longer overlays footers and bottom CTAs. The runtime measures the banner on show (and re-measures via `ResizeObserver` when it wraps on narrow viewports), publishing the size as `--cc-banner-height` on `:root`. Default zero-specificity rules consume the var as `padding-bottom` on `body` and `scroll-padding-bottom` on `:root`, both no-ops when the banner isn't visible. The padding transition matches the banner's existing 0.3s ease so the show/hide animates cleanly.

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -64,6 +64,23 @@
   --cc-border: #475569;
 }
 
+/* ── Host page spacing for the fixed banner ─────────────────
+ * The runtime sets `--cc-banner-height` on :root while the banner is
+ * visible (and clears it on dismiss). These rules consume it so the host
+ * page reserves real layout space — without them the banner overlays
+ * footers/CTAs at the bottom of the page. Wrapped in :where() for zero
+ * specificity so consumer body/root rules trivially override. The transition
+ * matches the banner's transform/opacity timing below to avoid a jolt.
+ */
+:where(body) {
+  padding-bottom: var(--cc-banner-height, 0);
+  transition: padding-bottom 0.3s ease;
+}
+
+:where(:root) {
+  scroll-padding-bottom: var(--cc-banner-height, 0);
+}
+
 /* ── Banner ─────────────────────────────────────────────── */
 
 .cc-banner {

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -180,7 +180,7 @@ function createPolicyLinkHTML(
 function createBannerHTML(config: SerializableConsentConfig, text: ResolvedConsentText): string {
   const policyLink = createPolicyLinkHTML(config.cookiePolicy, 'cc-policy-link');
   return `
-    <div class="cc-banner" id="${BANNER_ID}" role="region" aria-label="Cookie consent" aria-hidden="true">
+    <div class="cc-banner" id="${BANNER_ID}" role="region" aria-label="Cookie consent" aria-hidden="true" inert>
       <div class="cc-banner-inner">
         <p class="cc-banner-text">
           ${escapeHtml(text.bannerText)}
@@ -253,6 +253,7 @@ function createModalHTML(config: SerializableConsentConfig, text: ResolvedConsen
       aria-labelledby="${MODAL_TITLE_ID}"
       aria-hidden="true"
       tabindex="-1"
+      inert
     >
       <div class="cc-modal-inner">
         <div class="cc-modal-header">
@@ -324,6 +325,10 @@ export function showBanner(): void {
   if (!el) return;
   el.classList.add('cc-visible');
   el.setAttribute('aria-hidden', 'false');
+  // `inert` is paired with aria-hidden so axe `aria-hidden-focus` is
+  // satisfied when the banner is dismissed: the subtree is unfocusable AND
+  // hidden from AT, instead of just visually hidden with focusable buttons.
+  el.removeAttribute('inert');
 
   updateBannerHeightVar(el);
   // Re-measure on viewport resize (banner wraps on narrow widths) so the
@@ -338,6 +343,7 @@ export function hideBanner(): void {
   const el = document.getElementById(BANNER_ID);
   el?.classList.remove('cc-visible');
   el?.setAttribute('aria-hidden', 'true');
+  el?.setAttribute('inert', '');
 
   bannerResizeObserver?.disconnect();
   bannerResizeObserver = null;
@@ -417,6 +423,9 @@ export function showModal(): void {
 
   modal.classList.add('cc-visible');
   modal.setAttribute('aria-hidden', 'false');
+  // Drop `inert` before the focus dance below — inert blocks programmatic
+  // focus too, so leaving it on would break the requestAnimationFrame focus.
+  modal.removeAttribute('inert');
   if (overlay) {
     overlay.classList.add('cc-visible');
     overlay.setAttribute('aria-hidden', 'false');
@@ -438,6 +447,7 @@ export function hideModal(): void {
   if (modal) {
     modal.classList.remove('cc-visible');
     modal.setAttribute('aria-hidden', 'true');
+    modal.setAttribute('inert', '');
   }
   if (overlay) {
     overlay.classList.remove('cc-visible');

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -140,8 +140,10 @@ const MODAL_ID = 'cc-modal';
 const MODAL_TITLE_ID = 'cc-modal-title';
 const OVERLAY_ID = 'cc-overlay';
 const BANNER_ID = 'cc-banner';
+const BANNER_HEIGHT_VAR = '--cc-banner-height';
 
 let previouslyFocused: HTMLElement | null = null;
+let bannerResizeObserver: ResizeObserver | null = null;
 
 function escapeHtml(str: string): string {
   return str
@@ -305,16 +307,41 @@ export function setContainerTheme(mode: 'auto' | 'light' | 'dark'): void {
   }
 }
 
+/**
+ * Publish the banner's measured height as `--cc-banner-height` on :root so
+ * default `:where(body) { padding-bottom: var(--cc-banner-height) }` (and
+ * `scroll-padding-bottom`) reserve real layout space for the fixed banner.
+ * Without this the host page's footer sits behind the banner.
+ */
+function updateBannerHeightVar(el: HTMLElement): void {
+  const root = document.documentElement;
+  if (!root) return;
+  root.style.setProperty(BANNER_HEIGHT_VAR, `${el.getBoundingClientRect().height}px`);
+}
+
 export function showBanner(): void {
   const el = document.getElementById(BANNER_ID);
-  el?.classList.add('cc-visible');
-  el?.setAttribute('aria-hidden', 'false');
+  if (!el) return;
+  el.classList.add('cc-visible');
+  el.setAttribute('aria-hidden', 'false');
+
+  updateBannerHeightVar(el);
+  // Re-measure on viewport resize (banner wraps on narrow widths) so the
+  // reserved space stays accurate. Feature-detected for older targets.
+  if (typeof ResizeObserver !== 'undefined' && !bannerResizeObserver) {
+    bannerResizeObserver = new ResizeObserver(() => updateBannerHeightVar(el));
+    bannerResizeObserver.observe(el);
+  }
 }
 
 export function hideBanner(): void {
   const el = document.getElementById(BANNER_ID);
   el?.classList.remove('cc-visible');
   el?.setAttribute('aria-hidden', 'true');
+
+  bannerResizeObserver?.disconnect();
+  bannerResizeObserver = null;
+  document.documentElement?.style.removeProperty(BANNER_HEIGHT_VAR);
 }
 
 /**

--- a/playground/e2e/banner.spec.ts
+++ b/playground/e2e/banner.spec.ts
@@ -30,4 +30,32 @@ test.describe('Banner', () => {
     await expect(link).toHaveAttribute('href', '/cookie-policy');
     await expect(link).toHaveText('Cookie Policy');
   });
+
+  test('publishes --cc-banner-height while visible and clears it on dismiss', async ({ page }) => {
+    await expectBannerVisible(page, true);
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() =>
+          document.documentElement.style.getPropertyValue('--cc-banner-height').trim(),
+        ),
+      )
+      .toMatch(/^\d+(\.\d+)?px$/);
+
+    const heightPx = await page.evaluate(() =>
+      parseFloat(document.documentElement.style.getPropertyValue('--cc-banner-height')),
+    );
+    expect(heightPx).toBeGreaterThan(0);
+
+    await page.locator('[data-cc=accept-all]').click();
+    await expectBannerVisible(page, false);
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() =>
+          document.documentElement.style.getPropertyValue('--cc-banner-height'),
+        ),
+      )
+      .toBe('');
+  });
 });

--- a/playground/e2e/banner.spec.ts
+++ b/playground/e2e/banner.spec.ts
@@ -31,6 +31,25 @@ test.describe('Banner', () => {
     await expect(link).toHaveText('Cookie Policy');
   });
 
+  test('toggles `inert` alongside aria-hidden so axe `aria-hidden-focus` passes', async ({
+    page,
+  }) => {
+    const banner = page.locator('#cc-banner');
+    await expectBannerVisible(page, true);
+    await expect(banner).not.toHaveAttribute('inert', /.*/);
+
+    await page.locator('[data-cc=accept-all]').click();
+    await expectBannerVisible(page, false);
+    await expect(banner).toHaveAttribute('inert', /.*/);
+
+    const acceptFocusable = await page.evaluate(() => {
+      const btn = document.querySelector<HTMLElement>('[data-cc=accept-all]');
+      btn?.focus();
+      return document.activeElement === btn;
+    });
+    expect(acceptFocusable).toBe(false);
+  });
+
   test('publishes --cc-banner-height while visible and clears it on dismiss', async ({ page }) => {
     await expectBannerVisible(page, true);
 

--- a/playground/e2e/modal.spec.ts
+++ b/playground/e2e/modal.spec.ts
@@ -54,6 +54,21 @@ test.describe('Preferences modal', () => {
     await expect(modal).toHaveAttribute('aria-labelledby', 'cc-modal-title');
   });
 
+  test('toggles `inert` alongside aria-hidden so axe `aria-hidden-focus` passes', async ({
+    page,
+  }) => {
+    const modal = page.locator('#cc-modal');
+    await expect(modal).toHaveAttribute('inert', /.*/);
+
+    await page.locator('[data-cc=manage]').click();
+    await expectModalVisible(page, true);
+    await expect(modal).not.toHaveAttribute('inert', /.*/);
+
+    await page.keyboard.press('Escape');
+    await expectModalVisible(page, false);
+    await expect(modal).toHaveAttribute('inert', /.*/);
+  });
+
   test('modal accept-all works same as banner accept-all', async ({ page }) => {
     await page.locator('[data-cc=manage]').click();
     await page.locator('[data-cc=modal-accept-all]').click();


### PR DESCRIPTION
## Summary

Promotes two patches from `dev` to `main` to ship as **v0.3.1**. Merging this PR triggers `publish.yml`, which will open the "Version Packages" PR that bumps the version, regenerates `CHANGELOG.md`, and removes the changeset files. Merging that follow-up PR publishes to npm.

### Included

- #98 — `fix(ui): reserve layout space so banner no longer overlays page footer`
- #100 — `fix(a11y): pair aria-hidden with inert on banner/modal`

Both ship as `patch` changesets, so the resulting version will be `0.3.1`.

## Test plan

- [x] Per-PR Playwright (52 tests) green on each merged commit
- [ ] After merge: `publish.yml` opens the Version Packages PR
- [ ] After Version PR merge: npm shows `@zdenekkurecka/astro-consent@0.3.1`, GitHub Release `astro-consent-v0.3.1` exists, provenance attestation visible
- [ ] Back-merge `main` → `dev` so `dev` picks up the bumped `package.json` + `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
