### PR TITLE
fix: move focus out of banner/modal before applying aria-hidden

### DIFF
--- a/.changeset/tidy-banners-focus.md
+++ b/.changeset/tidy-banners-focus.md
@@ -1,0 +1,5 @@
+---
+"@zdenekkurecka/astro-consent": patch
+---
+
+Fix accessibility warning when dismissing the banner or modal. Accepting/rejecting consent directly from the banner left focus on the just-clicked button while `aria-hidden`/`inert` were applied to its ancestor, hiding a focused node from assistive tech and logging a console warning. `hideBanner()` and `hideModal()` now move focus out of the subtree before hiding it.

--- a/packages/astro-consent/src/ui.ts
+++ b/packages/astro-consent/src/ui.ts
@@ -320,6 +320,22 @@ function updateBannerHeightVar(el: HTMLElement): void {
   root.style.setProperty(BANNER_HEIGHT_VAR, `${el.getBoundingClientRect().height}px`);
 }
 
+/**
+ * Drops focus to `<body>` if it currently sits inside `el`. Must run *before*
+ * `aria-hidden`/`inert` are applied to `el`: hiding an ancestor of the focused
+ * element (e.g. the just-clicked "Accept all" button) hides a focused node
+ * from assistive tech and logs a console warning ("Blocked aria-hidden on an
+ * element because its descendant retained focus"). `inert` blurs descendants
+ * too, but only after `aria-hidden` has already been set, so the warning still
+ * fires unless focus is moved out first.
+ */
+function blurFocusWithin(el: HTMLElement): void {
+  const active = document.activeElement;
+  if (active instanceof HTMLElement && el.contains(active)) {
+    active.blur();
+  }
+}
+
 export function showBanner(): void {
   const el = document.getElementById(BANNER_ID);
   if (!el) return;
@@ -341,9 +357,11 @@ export function showBanner(): void {
 
 export function hideBanner(): void {
   const el = document.getElementById(BANNER_ID);
-  el?.classList.remove('cc-visible');
-  el?.setAttribute('aria-hidden', 'true');
-  el?.setAttribute('inert', '');
+  if (!el) return;
+  blurFocusWithin(el);
+  el.classList.remove('cc-visible');
+  el.setAttribute('aria-hidden', 'true');
+  el.setAttribute('inert', '');
 
   bannerResizeObserver?.disconnect();
   bannerResizeObserver = null;
@@ -445,6 +463,10 @@ export function hideModal(): void {
   const modal = document.getElementById(MODAL_ID);
   const overlay = document.getElementById(OVERLAY_ID);
   if (modal) {
+    // Move focus off any inner control (e.g. the clicked "Accept all" button)
+    // before hiding — the focus restoration below may no-op if its target sits
+    // in an inert subtree, so don't rely on it to clear focus from the modal.
+    blurFocusWithin(modal);
     modal.classList.remove('cc-visible');
     modal.setAttribute('aria-hidden', 'true');
     modal.setAttribute('inert', '');

--- a/playground/e2e/banner.spec.ts
+++ b/playground/e2e/banner.spec.ts
@@ -50,6 +50,38 @@ test.describe('Banner', () => {
     expect(acceptFocusable).toBe(false);
   });
 
+  test('dismissing the banner moves focus out before applying aria-hidden', async ({ page }) => {
+    await expectBannerVisible(page, true);
+
+    // Spy on the banner's own setAttribute to capture whether focus was still
+    // inside the subtree at the exact instant `aria-hidden="true"` was applied.
+    // The bug left the just-clicked button focused there, which hides a focused
+    // node from assistive tech ("Blocked aria-hidden … descendant retained
+    // focus"). `inert` blurs it one line later, so checking focus *after*
+    // hideBanner() can't catch the regression — only this instant can.
+    await page.evaluate(() => {
+      const banner = document.getElementById('cc-banner')!;
+      const original = banner.setAttribute.bind(banner);
+      (window as Window & { __focusInBannerAtHide?: boolean }).__focusInBannerAtHide = undefined;
+      banner.setAttribute = (name: string, value: string) => {
+        if (name === 'aria-hidden' && value === 'true') {
+          (window as Window & { __focusInBannerAtHide?: boolean }).__focusInBannerAtHide =
+            !!document.activeElement && banner.contains(document.activeElement);
+        }
+        return original(name, value);
+      };
+    });
+
+    // A real click focuses the button; that's the precondition for the bug.
+    await page.locator('[data-cc=accept-all]').click();
+    await expectBannerVisible(page, false);
+
+    const focusInBannerAtHide = await page.evaluate(
+      () => (window as Window & { __focusInBannerAtHide?: boolean }).__focusInBannerAtHide,
+    );
+    expect(focusInBannerAtHide).toBe(false);
+  });
+
   test('publishes --cc-banner-height while visible and clears it on dismiss', async ({ page }) => {
     await expectBannerVisible(page, true);
 


### PR DESCRIPTION
Closes #104. Targets a **0.3.2** patch release.

## Problem

Accepting/rejecting consent **directly from the banner** logged a console warning and momentarily hid a focused element from assistive tech:

```
Blocked aria-hidden on an element because its descendant retained focus.
Element with focus: <button.cc-btn cc-btn-primary>
Ancestor with aria-hidden: <div.cc-banner#cc-banner … aria-hidden="true" inert>
```

`hideBanner()` set `aria-hidden="true"` on `#cc-banner` while the just-clicked button still had focus. `inert` does blur the descendant — but only on the *next line*, after the warning has already fired. `hideModal()` had the same latent bug when the modal is closed via an inner button (e.g. `modal-accept-all`).

## Fix

- New `blurFocusWithin(el)` helper — drops focus to `<body>` if it currently sits inside `el`.
- Called at the top of `hideBanner()` and `hideModal()`, **before** `aria-hidden`/`inert` are applied.
- `hideBanner()` also gains an early `if (!el) return` guard (consistent with `showBanner()`), so the attribute calls are no longer optional-chained.

## Test

New regression test in `banner.spec.ts` spies on the banner's `setAttribute` and asserts focus has already left the subtree **at the exact instant `aria-hidden="true"` is applied** — the only observable point that distinguishes fixed from broken (`inert` blurs the button one line later, so checking focus *after* `hideBanner()` can't catch it).

Validated by stash-reverting the `ui.ts` fix: with the fix removed the new test fails (`__focusInBannerAtHide` is `true`); with it in place the full suite is **53/53 green**.
