### PR TITLE
chore: back-merge main after v0.3.2 release

### DIFF
--- a/.changeset/tidy-banners-focus.md
+++ b/.changeset/tidy-banners-focus.md
@@ -1,5 +1,0 @@
----
-"@zdenekkurecka/astro-consent": patch
----
-
-Fix accessibility warning when dismissing the banner or modal. Accepting/rejecting consent directly from the banner left focus on the just-clicked button while `aria-hidden`/`inert` were applied to its ancestor, hiding a focused node from assistive tech and logging a console warning. `hideBanner()` and `hideModal()` now move focus out of the subtree before hiding it.

--- a/packages/astro-consent/CHANGELOG.md
+++ b/packages/astro-consent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @zdenekkurecka/astro-consent
 
+## 0.3.2
+
+### Patch Changes
+
+- [#105](https://github.com/zdenekkurecka/astro-consent/pull/105) [`fc05ac8`](https://github.com/zdenekkurecka/astro-consent/commit/fc05ac8b0711c9d109ef48fa32e6de7e2f337e83) Thanks [@zdenekkurecka](https://github.com/zdenekkurecka)! - Fix accessibility warning when dismissing the banner or modal. Accepting/rejecting consent directly from the banner left focus on the just-clicked button while `aria-hidden`/`inert` were applied to its ancestor, hiding a focused node from assistive tech and logging a console warning. `hideBanner()` and `hideModal()` now move focus out of the subtree before hiding it.
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/astro-consent/package.json
+++ b/packages/astro-consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zdenekkurecka/astro-consent",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Astro integration for GDPR/ePrivacy-friendly cookie consent: banner, preferences modal, runtime API, category-based consent state, strict-CSP safe, works with or without View Transitions.",
   "keywords": [
     "astro",


### PR DESCRIPTION
Back-merge `main` into `dev` after the **v0.3.2** release, so `dev` picks up the version bump and changelog (same flow as `chore/sync-main-after-031` after v0.3.1).

## Commits coming into `dev`

- `dd151cc` Merge pull request #107 from zdenekkurecka/changeset-release/main
- `d485584` chore(release): version packages — `0.3.1` → `0.3.2`, CHANGELOG entry, consumed changeset removed
- `cd0e122` Merge pull request #106 from zdenekkurecka/dev

No code changes — release metadata only.
