### PR TITLE
chore: back-merge main after 0.3.3 release

### DIFF
--- a/.changeset/astro-7-support.md
+++ b/.changeset/astro-7-support.md
@@ -1,9 +1,0 @@
----
-"@zdenekkurecka/astro-consent": patch
----
-
-Add support for Astro 7. The peer dependency range is now `astro@^5 || ^6 || ^7`.
-
-No integration code changes were required — Astro 7's integration API surface this package relies on is unchanged: the `astro:config:setup` hook, the `injectScript` stages (`page-ssr`, `page`, `head-inline`), `updateConfig` Vite-plugin registration, the `astro:page-load` client event (View Transitions), and the `astro/runtime/server` type path all carry over. The virtual-module Vite plugin resolves correctly under Astro 7's Vite 8 / Rolldown bundler, and the full Playwright e2e suite passes against Astro 7.
-
-Note: Astro 7 itself requires Node `>=22.12.0` (it dropped Node 18 and 20). This package keeps a permissive `engines.node >=18.17.0` so Astro 5/6 users on older Node are unaffected; projects on Astro 7 must run Node `>=22.12.0`, as enforced by Astro.

--- a/packages/astro-consent/CHANGELOG.md
+++ b/packages/astro-consent/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @zdenekkurecka/astro-consent
 
+## 0.3.3
+
+### Patch Changes
+
+- [#110](https://github.com/zdenekkurecka/astro-consent/pull/110) [`3d5da19`](https://github.com/zdenekkurecka/astro-consent/commit/3d5da19f48543cae41dd84f5b439de4ebb062656) Thanks [@zdenekkurecka](https://github.com/zdenekkurecka)! - Add support for Astro 7. The peer dependency range is now `astro@^5 || ^6 || ^7`.
+
+  No integration code changes were required — Astro 7's integration API surface this package relies on is unchanged: the `astro:config:setup` hook, the `injectScript` stages (`page-ssr`, `page`, `head-inline`), `updateConfig` Vite-plugin registration, the `astro:page-load` client event (View Transitions), and the `astro/runtime/server` type path all carry over. The virtual-module Vite plugin resolves correctly under Astro 7's Vite 8 / Rolldown bundler, and the full Playwright e2e suite passes against Astro 7.
+
+  Note: Astro 7 itself requires Node `>=22.12.0` (it dropped Node 18 and 20). This package keeps a permissive `engines.node >=18.17.0` so Astro 5/6 users on older Node are unaffected; projects on Astro 7 must run Node `>=22.12.0`, as enforced by Astro.
+
 ## 0.3.2
 
 ### Patch Changes

--- a/packages/astro-consent/package.json
+++ b/packages/astro-consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zdenekkurecka/astro-consent",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Astro integration for GDPR/ePrivacy-friendly cookie consent: banner, preferences modal, runtime API, category-based consent state, strict-CSP safe, works with or without View Transitions.",
   "keywords": [
     "astro",


### PR DESCRIPTION
Syncs `dev` with `main` after the **0.3.3** release: picks up the version bump (0.3.2 → 0.3.3), the CHANGELOG entry, and the consumed `astro-7-support` changeset removal. Mirrors the post-release back-merge done for prior releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)