### PR TITLE
fix: GCM head placement docs, toggle contrast, essentialBadge docs

### DIFF
--- a/.changeset/quiet-poems-repeat.md
+++ b/.changeset/quiet-poems-repeat.md
@@ -1,0 +1,60 @@
+---
+'@zdenekkurecka/astro-consent': patch
+---
+
+Fix three reported defects: the Google Consent Mode placement claim, the
+preference toggle's contrast, and the missing `essentialBadge` docs.
+
+**Google Consent Mode snippet placement was documented wrong ([#115](https://github.com/zdenekkurecka/astro-consent/issues/115)).**
+The README, the `googleConsentMode` doc comments (which ship in `dist/types.d.ts`
+and surface as editor tooltips), `docs/recipes/gtm.md` and `docs/recipes/ga4.md`
+all claimed the default-denied snippet is injected "at the top of `<head>`". It
+isn't — Astro emits injected `head-inline` scripts *after* the route's own
+`<head>` content, so the snippet is the **last** thing in `<head>`. A loader
+authored in your layout's `<head>`, which both recipes told you to do, therefore
+ran *before* the consent default.
+
+The recipes now place the Google tag at the top of `<body>`, which is ordered
+after the whole of `<head>` and so is genuinely guaranteed, and document
+injecting it from an integration listed after `cookieConsent()` as the
+in-`<head>` alternative. The README's GA4 example was additionally broken on its
+own terms: it called bare `gtag('js', …)` / `gtag('config', …)` without
+bootstrapping `window.dataLayer` and `gtag`, so following the old "drop it
+anywhere in your layout" advice into `<head>` threw
+`ReferenceError: gtag is not defined` and dropped the GA4 config entirely.
+
+No runtime behaviour changed — the snippet lands where it always did, and still
+precedes everything in `<body>`.
+
+**Preference toggle failed WCAG 2.1 SC 1.4.11 in the off state ([#116](https://github.com/zdenekkurecka/astro-consent/issues/116)).**
+`.cc-toggle-slider` painted its off-state track with `--cc-border` and its knob
+with hard-coded `white`, giving **1.18:1** track-vs-backdrop and **1.23:1**
+knob-vs-track in the light palette — no boundary anywhere near the required 3:1,
+so the control was effectively invisible to low-vision users. `--cc-border` also
+draws the banner hairline, the `.cc-badge` outline and the secondary button's
+border and hover fill, so overriding it could not fix the toggle without
+wrecking those.
+
+The toggle now has its own tokens, `--cc-toggle-off` and `--cc-toggle-knob`, so
+the two readings no longer compete. Defaults clear 3:1 on both boundaries in
+both palettes, measured against the `.cc-category` card the toggle actually sits
+on rather than `--cc-bg`:
+
+| | track vs card | knob vs track |
+| --- | --- | --- |
+| light `#64748b` | 4.56:1 | 4.76:1 |
+| dark `#7a8699` | 3.75:1 | 3.69:1 |
+
+Consumers already overriding `--cc-border` keep their hairline; override
+`--cc-toggle-off` to restyle the toggle.
+
+**`essentialBadge` was undocumented ([#117](https://github.com/zdenekkurecka/astro-consent/issues/117)).**
+The key appeared nowhere in the README — not in the `ConsentText` reference
+block and not in the localization example — so anyone translating from those
+shipped a stray English "Required" pill next to a fully translated Essential
+row. Both places now list it.
+
+Also adds regression coverage for the first two: the e2e suite now asserts the
+GCM snippet precedes everything in `<body>` and that the consent default is
+queued ahead of the page's own `gtag` calls, and checks the toggle's contrast
+ratios in both the light and dark palettes.

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ interface ConsentConfig {
 
   /**
    * Google Consent Mode v2 integration. When set, the integration injects an
-   * inline snippet at the top of `<head>` to pre-declare denied defaults, and
+   * inline snippet into `<head>` to pre-declare denied defaults, and
    * auto-dispatches `gtag('consent', 'update', …)` on every consent event.
    *
    * Opt-in. Requires `'unsafe-inline'` (or a matching hash) under strict CSP —
@@ -254,6 +254,7 @@ interface ConsentText {
   // Essential category
   essentialLabel?: string;
   essentialDescription?: string;
+  essentialBadge?: string;   // the "Required" pill on the essential row
 
   /** Per-category label/description overrides (key = category key). */
   categories?: Record<string, { label?: string; description?: string }>;
@@ -506,7 +507,7 @@ cookieConsent({
 
 What the integration does for you:
 
-1. Injects an inline snippet at the top of `<head>` that bootstraps
+1. Injects an inline snippet into `<head>` that bootstraps
    `window.dataLayer` + `gtag` and calls `gtag('consent', 'default', { …,
    wait_for_update: 500 })` with every mapped signal set to `"denied"` (unless
    overridden via `defaults` / `regions`).
@@ -516,21 +517,59 @@ What the integration does for you:
 3. Forwards `adsDataRedaction` / `urlPassthrough` as `gtag('set', …)` calls in
    the default snippet.
 
-Drop your GA4 / Google Ads tag anywhere in your layout (or gate it via
-`data-cc-category` — the two compose) and it will pick up the consent state
-automatically:
+**Where to put your Google tag.** Astro emits injected `head-inline` scripts
+*after* the route's own `<head>` content, so the default snippet is the last
+thing in `<head>` — not the first. It runs before everything in `<body>`, but
+*after* any script your layout authors in `<head>`. Load your tag from the top
+of `<body>`:
 
 ```astro
-<script
-  is:inline
-  async
-  src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"
-></script>
-<script is:inline>
-  gtag('js', new Date());
-  gtag('config', 'G-XXXXXXX');
-</script>
+---
+// src/layouts/Layout.astro
+---
+<html>
+  <head>
+    <slot name="head" />
+  </head>
+  <body>
+    <!-- After </head>, so the integration's consent default has already run. -->
+    <script
+      is:inline
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"
+    ></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', 'G-XXXXXXX');
+    </script>
+    <slot />
+  </body>
+</html>
 ```
+
+If you need the tag in `<head>`, inject it from an integration listed *after*
+`cookieConsent()` — Astro emits injected head-inline scripts in
+integrations-array order:
+
+```js
+// astro.config.mjs
+integrations: [
+  cookieConsent({ /* … googleConsentMode … */ }),
+  // Must come after cookieConsent().
+  {
+    name: 'gtag-loader',
+    hooks: {
+      'astro:config:setup': ({ injectScript }) =>
+        injectScript('head-inline', GTAG_LOADER_SNIPPET),
+    },
+  },
+],
+```
+
+Either way the tag picks up the consent state automatically. You can also gate
+it via `data-cc-category` — the two compose.
 
 **CSP caveat.** The default snippet is inline, so enabling
 `googleConsentMode` requires `script-src` to include `'unsafe-inline'` or a
@@ -616,6 +655,7 @@ cookieConsent({
       savePreferences: 'Save preferences',
       essentialLabel: 'Essential',
       essentialDescription: 'Required for the website to function. Cannot be disabled.',
+      essentialBadge: 'Required',
       categories: {
         analytics: {
           label: 'Analytics',
@@ -633,6 +673,7 @@ cookieConsent({
       savePreferences: 'Uložit předvolby',
       essentialLabel: 'Nezbytné',
       essentialDescription: 'Nutné pro fungování webu. Nelze vypnout.',
+      essentialBadge: 'Vždy zapnuto',
       categories: {
         analytics: {
           label: 'Analytické',
@@ -674,6 +715,15 @@ stylesheet without forking anything:
   --cc-font-family: 'Inter', sans-serif;
 }
 ```
+
+The preference toggle has its own `--cc-toggle-off` / `--cc-toggle-knob` pair
+rather than reusing `--cc-border`, because the two want opposite things:
+`--cc-border` draws hairlines (the banner's top rule, the `.cc-badge` outline,
+the secondary button), while the toggle's off state has to clear
+[WCAG 1.4.11](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html)'s
+3:1 for non-text contrast. Remapping `--cc-border` to your own palette therefore
+leaves the toggle legible. If you do restyle the toggle, keep both the track
+against the category card *and* the knob against the track at 3:1 or better.
 
 ### Use with a strict Content Security Policy
 

--- a/docs/recipes/ga4.md
+++ b/docs/recipes/ga4.md
@@ -49,7 +49,7 @@ export default defineConfig({
 });
 ```
 
-### 2. Drop the GA4 tag in your layout
+### 2. Drop the GA4 tag at the top of `<body>`
 
 ```astro
 ---
@@ -57,6 +57,10 @@ export default defineConfig({
 ---
 <html>
   <head>
+    <slot name="head" />
+  </head>
+  <body>
+    <!-- After </head>, so the integration's consent default has already run. -->
     <script
       is:inline
       async
@@ -68,22 +72,26 @@ export default defineConfig({
       gtag('js', new Date());
       gtag('config', 'G-XXXXXXX');
     </script>
-  </head>
-  <body><slot /></body>
+    <slot />
+  </body>
 </html>
 ```
 
-The integration's GCM snippet runs *before* these tags at the top of `<head>`
-(see the README). GA4 boots, reads the denied-by-default signals, and only
-starts writing cookies after `astro-consent:consent` triggers the
-`gtag('consent', 'update', ...)` bridge.
+The integration's GCM snippet is injected into `<head>`, so it runs before
+anything in `<body>` — including these tags. GA4 boots, reads the
+denied-by-default signals, and only starts writing cookies after
+`astro-consent:consent` triggers the `gtag('consent', 'update', ...)` bridge.
 
 ### Gotchas
 
-- **Order matters.** The integration's GCM snippet must execute before
-  `gtag.js`. It does, because the integration injects at the top of `<head>`
-  — as long as you don't inject GA4 *before* the integration's output (e.g.
-  via a custom Astro hook earlier in the pipeline), you're fine.
+- **Order matters, and `<head>` is *not* safe.** The GCM snippet must run
+  before `gtag('config', …)`. Astro emits injected `head-inline` scripts
+  *after* the route's own `<head>` content, so the snippet is the **last**
+  thing in `<head>`, not the first. A tag authored in your layout's `<head>`
+  therefore runs *first* — the exact inversion Consent Mode exists to
+  prevent. Put the tag at the top of `<body>` as above, or inject it from an
+  integration listed after `cookieConsent()` in `integrations` (injected
+  head-inline scripts are emitted in integrations-array order).
 - **CSP.** The GCM default snippet is inline, so `script-src` must allow
   `'unsafe-inline'` (or a matching hash). Same goes for the inline
   `gtag('config', ...)` call above — extract it into an external file if you

--- a/docs/recipes/gtm.md
+++ b/docs/recipes/gtm.md
@@ -49,7 +49,7 @@ export default defineConfig({
 });
 ```
 
-### 2. Drop the GTM snippet in your layout
+### 2. Drop the GTM snippet at the top of `<body>`
 
 ```astro
 ---
@@ -57,6 +57,10 @@ export default defineConfig({
 ---
 <html>
   <head>
+    <slot name="head" />
+  </head>
+  <body>
+    <!-- After </head>, so the integration's consent default has already run. -->
     <script is:inline>
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -65,8 +69,7 @@ export default defineConfig({
       f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','GTM-XXXXXXX');
     </script>
-  </head>
-  <body>
+
     <!-- GTM noscript fallback. -->
     <noscript>
       <iframe
@@ -81,8 +84,18 @@ export default defineConfig({
 </html>
 ```
 
-The integration emits its GCM default snippet at the top of `<head>` *before*
-GTM loads, so `gtag('consent', 'default', …)` runs first. Each tag you
+The integration injects its GCM default snippet into `<head>`, so it runs
+before everything in `<body>` — including the loader above — and
+`gtag('consent', 'default', …)` lands first.
+
+Note that `<head>` is **not** a safe place for the loader: Astro emits
+injected `head-inline` scripts *after* the route's own `<head>` content, so
+the GCM snippet is the last thing in `<head>`, not the first. A loader
+authored in your layout's `<head>` would run before it. If you do need it in
+`<head>`, inject it from an integration listed after `cookieConsent()` —
+injected head-inline scripts are emitted in integrations-array order.
+
+Each tag you
 configure in the GTM UI should have its "Consent Settings" set to "Require
 additional consent" for the relevant signals — GTM will then defer or fire
 them based on the signal state.

--- a/packages/astro-consent/src/gcm.ts
+++ b/packages/astro-consent/src/gcm.ts
@@ -124,8 +124,10 @@ function assertValue(value: unknown, path: string): void {
 }
 
 /**
- * Build the inline snippet that pre-declares GCM defaults at the top of
- * `<head>`. The snippet:
+ * Build the inline snippet that pre-declares GCM defaults in `<head>`.
+ * (Astro emits it after the route's own `<head>` content — see
+ * `GoogleConsentModeConfig` for what that means for loader placement.)
+ * The snippet:
  *
  *  1. Initializes `window.dataLayer` and a global `gtag(…)` helper.
  *  2. Calls `gtag('consent', 'default', { …denied…, wait_for_update })` with

--- a/packages/astro-consent/src/integration.ts
+++ b/packages/astro-consent/src/integration.ts
@@ -67,9 +67,14 @@ export default function cookieConsent<K extends string = string>(
         injectScript('page', 'import "virtual:astro-consent/init";');
 
         // Google Consent Mode v2: inject the default-denied snippet inline
-        // at the top of <head> so `gtag('consent', 'default', …)` runs before
-        // any downstream GTM/gtag.js. This is the one case where we emit an
-        // inline <script> — opt-in and documented as a CSP caveat.
+        // into <head>. NOTE: Astro emits injected `head-inline` scripts at
+        // the *end* of <head>, after the route's own head content — this is
+        // not "the top of <head>". The snippet therefore precedes everything
+        // in <body>, but a loader authored in the layout's own <head> would
+        // still run first; the docs tell consumers to load GTM/gtag.js from
+        // the top of <body> or from an integration ordered after this one.
+        // This is the one case where we emit an inline <script> — opt-in and
+        // documented as a CSP caveat.
         if (gcm && gcm.enabled !== false) {
           injectScript('head-inline', buildGcmDefaultSnippet(gcm));
         }

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -11,6 +11,8 @@
   --cc-text: #0f172a;
   --cc-text-muted: #64748b;
   --cc-border: #e2e8f0;
+  --cc-toggle-off: #64748b;
+  --cc-toggle-knob: #ffffff;
   --cc-radius: 1.5rem;
   --cc-radius-pill: 9999px;
   --cc-font-family: inherit;
@@ -20,7 +22,8 @@
  * Zero specificity via :where() so any user override in their
  * own stylesheet wins without !important.
  * WCAG 2.1 AA: text on --cc-bg and --cc-text-muted on --cc-bg
- * both clear 4.5:1 contrast.
+ * both clear 4.5:1 contrast (1.4.3), and --cc-toggle-off /
+ * --cc-toggle-knob clear 3:1 (1.4.11) — see .cc-toggle-slider.
  */
 @media (prefers-color-scheme: dark) {
   :where(:root) {
@@ -32,6 +35,8 @@
     --cc-text: #f1f5f9;
     --cc-text-muted: #94a3b8;
     --cc-border: #475569;
+    --cc-toggle-off: #7a8699;
+    --cc-toggle-knob: #ffffff;
   }
 }
 
@@ -51,6 +56,8 @@
   --cc-text: #0f172a;
   --cc-text-muted: #64748b;
   --cc-border: #e2e8f0;
+  --cc-toggle-off: #64748b;
+  --cc-toggle-knob: #ffffff;
 }
 
 :where([data-cc-theme='dark']) {
@@ -62,6 +69,8 @@
   --cc-text: #f1f5f9;
   --cc-text-muted: #94a3b8;
   --cc-border: #475569;
+  --cc-toggle-off: #7a8699;
+  --cc-toggle-knob: #ffffff;
 }
 
 /* ── Host page spacing for the fixed banner ─────────────────
@@ -283,7 +292,17 @@
   color: var(--cc-text-muted);
 }
 
-/* ── Toggle Switch ──────────────────────────────────────── */
+/* ── Toggle Switch ──────────────────────────────────────────
+ * The off state needs its own token, not --cc-border: WCAG 1.4.11
+ * wants 3:1 for a control's boundary, while --cc-border also draws
+ * the banner hairline, the .cc-badge outline and the secondary
+ * button's border + hover fill, where a faint value is correct.
+ * Both boundaries must clear 3:1 against the .cc-category card
+ * (#fafafa light / #232d3f dark), not against --cc-bg:
+ *   light  #64748b  4.56:1 track-vs-card, 4.76:1 knob-vs-track
+ *   dark   #7a8699  3.75:1 track-vs-card, 3.69:1 knob-vs-track
+ * The on state uses --cc-primary (4.95:1 / 3.76:1).
+ */
 
 .cc-toggle {
   position: relative;
@@ -303,7 +322,7 @@
 .cc-toggle-slider {
   position: absolute;
   inset: 0;
-  background-color: var(--cc-border);
+  background-color: var(--cc-toggle-off);
   border-radius: var(--cc-radius-pill);
   cursor: pointer;
   transition: background-color 0.2s ease;
@@ -316,7 +335,7 @@
   width: 1.125rem;
   left: 0.1875rem;
   bottom: 0.1875rem;
-  background-color: white;
+  background-color: var(--cc-toggle-knob);
   border-radius: 50%;
   transition: transform 0.2s ease;
   box-sizing: border-box;

--- a/packages/astro-consent/src/types.ts
+++ b/packages/astro-consent/src/types.ts
@@ -38,10 +38,13 @@ export type GoogleConsentRegionValue = GoogleConsentValue | GoogleConsentDefault
 /**
  * Google Consent Mode v2 configuration.
  *
- * When set, the integration injects an inline snippet at the top of `<head>`
- * that bootstraps `window.dataLayer` + `gtag` and calls
- * `gtag('consent', 'default', {...})` before any downstream GTM / gtag.js
- * loads. Subsequent `astro-consent:consent` and `astro-consent:change` events
+ * When set, the integration injects an inline snippet into `<head>` that
+ * bootstraps `window.dataLayer` + `gtag` and calls
+ * `gtag('consent', 'default', {...})`. Astro emits injected `head-inline`
+ * scripts *after* the route's own `<head>` content, so the snippet runs
+ * before anything in `<body>` but *after* any script your layout puts in
+ * `<head>` — load GTM / gtag.js from the top of `<body>`, or from an
+ * integration listed after `cookieConsent()`. Subsequent `astro-consent:consent` and `astro-consent:change` events
  * automatically fire `gtag('consent', 'update', {...})` with the signals
  * derived from `mapping`.
  *
@@ -218,9 +221,11 @@ export interface ConsentConfig<K extends string = string> {
 
   /**
    * Google Consent Mode v2 integration. When configured, an inline snippet
-   * is injected at the top of `<head>` to pre-declare denied defaults before
-   * any GTM/gtag.js loads, and consent events automatically translate into
-   * `gtag('consent', 'update', …)` calls.
+   * is injected into `<head>` to pre-declare denied defaults, and consent
+   * events automatically translate into `gtag('consent', 'update', …)`
+   * calls. The snippet is emitted after the route's own `<head>` content,
+   * so load GTM/gtag.js from the top of `<body>` (or from an integration
+   * listed after `cookieConsent()`) to keep it ahead of them.
    *
    * Opt-in — omit this to keep the integration strict-CSP safe.
    */

--- a/playground/e2e/gcm.spec.ts
+++ b/playground/e2e/gcm.spec.ts
@@ -133,4 +133,44 @@ test.describe('Google Consent Mode v2', () => {
       ad_storage: 'granted',
     });
   });
+
+  /**
+   * Regression guard for #115. The docs used to claim the snippet lands at the
+   * *top* of `<head>`; Astro actually emits injected `head-inline` scripts
+   * after the route's own head content, so it is the last thing in `<head>`.
+   * What we do guarantee — and what the recipes now tell consumers to rely on
+   * — is that it precedes everything in `<body>`.
+   */
+  test('default snippet is in <head>, ahead of everything in <body>', async ({ request }) => {
+    const html = await (await request.get('/gcm')).text();
+
+    const snippet = html.indexOf("gtag('consent','default'");
+    const headEnd = html.indexOf('</head>');
+    const bodyStart = html.indexOf('<body');
+    const pageLoader = html.indexOf('googletagmanager.com/gtag/js');
+    const pageConfig = html.indexOf("gtag('config', 'G-PLAYGRNDXX'");
+
+    expect(snippet).toBeGreaterThan(-1);
+    expect(headEnd).toBeGreaterThan(-1);
+    expect(headEnd).toBeLessThan(bodyStart);
+
+    // Inside <head> …
+    expect(snippet).toBeLessThan(headEnd);
+    // … and therefore ahead of the tag the recipes place at the top of <body>.
+    expect(pageLoader).toBeGreaterThan(headEnd);
+    expect(pageConfig).toBeGreaterThan(snippet);
+  });
+
+  test('consent default is queued before the page\'s own gtag calls', async ({ page }) => {
+    const entries = await readDataLayer(page);
+    const isCall = (e: unknown, cmd: string) => Array.isArray(e) && e[0] === cmd;
+
+    const firstDefault = entries.findIndex(
+      (e) => Array.isArray(e) && e[0] === 'consent' && e[1] === 'default',
+    );
+    const firstConfig = entries.findIndex((e) => isCall(e, 'config'));
+
+    expect(firstDefault).toBeGreaterThanOrEqual(0);
+    expect(firstConfig).toBeGreaterThan(firstDefault);
+  });
 });

--- a/playground/e2e/toggle-contrast.spec.ts
+++ b/playground/e2e/toggle-contrast.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect, type Page } from '@playwright/test';
+import { clearConsent } from './helpers';
+
+/**
+ * Regression guard for #116 — WCAG 2.1 SC 1.4.11 Non-text Contrast.
+ *
+ * The toggle needs 3:1 for the visual boundaries that identify it as a control
+ * and show its state:
+ *
+ *   - the track against whatever is painted behind it, and
+ *   - the knob against the track.
+ *
+ * The backdrop is *not* `--cc-bg`: the toggle sits inside `.cc-category`, which
+ * paints `rgba(var(--cc-tint-rgb), 0.02)` over the modal. Measuring against
+ * `--cc-bg` overstates the ratio, so we composite the real stack instead.
+ */
+
+const MIN_RATIO = 3;
+
+type Reading = { track: number; knob: number; trackColor: string };
+
+async function readToggleContrast(page: Page, category: string): Promise<Reading> {
+  return page.evaluate((key) => {
+    type Rgba = { r: number; g: number; b: number; a: number };
+
+    const parse = (value: string): Rgba => {
+      const n = value.match(/[\d.]+/g)?.map(Number) ?? [];
+      return { r: n[0] ?? 0, g: n[1] ?? 0, b: n[2] ?? 0, a: n.length > 3 ? n[3] : 1 };
+    };
+
+    const over = (top: Rgba, bottom: Rgba): Rgba => ({
+      r: top.r * top.a + bottom.r * (1 - top.a),
+      g: top.g * top.a + bottom.g * (1 - top.a),
+      b: top.b * top.a + bottom.b * (1 - top.a),
+      a: 1,
+    });
+
+    /** Flatten every translucent background between `el` and the first opaque one. */
+    const backdropOf = (el: Element): Rgba => {
+      const stack: Rgba[] = [];
+      for (let n = el.parentElement; n; n = n.parentElement) {
+        const bg = parse(getComputedStyle(n).backgroundColor);
+        if (bg.a > 0) stack.push(bg);
+        if (bg.a === 1) break;
+      }
+      // Assume a white canvas under everything, then paint bottom-up.
+      let out: Rgba = { r: 255, g: 255, b: 255, a: 1 };
+      for (let i = stack.length - 1; i >= 0; i--) out = over(stack[i], out);
+      return out;
+    };
+
+    const luminance = ({ r, g, b }: Rgba): number => {
+      const f = (v: number) => {
+        const c = v / 255;
+        return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+      };
+      return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+    };
+
+    const ratio = (a: Rgba, b: Rgba): number => {
+      const [x, y] = [luminance(a), luminance(b)];
+      return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
+    };
+
+    const input = document.querySelector(`input[data-cc-category="${key}"]`);
+    const slider = input?.nextElementSibling;
+    if (!slider) throw new Error(`no toggle for category "${key}"`);
+
+    const track = over(parse(getComputedStyle(slider).backgroundColor), backdropOf(slider));
+    const knob = over(
+      parse(getComputedStyle(slider, '::before').backgroundColor),
+      track,
+    );
+
+    return {
+      track: ratio(track, backdropOf(slider)),
+      knob: ratio(knob, track),
+      trackColor: getComputedStyle(slider).backgroundColor,
+    };
+  }, category);
+}
+
+/** Resolve a custom property to the `rgb(...)` form `getComputedStyle` reports. */
+async function resolveToken(page: Page, token: string): Promise<string> {
+  return page.evaluate((name) => {
+    const probe = document.createElement('span');
+    probe.style.color = `var(${name})`;
+    document.body.appendChild(probe);
+    const value = getComputedStyle(probe).color;
+    probe.remove();
+    return value;
+  }, token);
+}
+
+async function openPreferences(page: Page) {
+  await page.goto('/');
+  await clearConsent(page);
+  await page.reload();
+
+  // `.cc-toggle-slider` animates `background-color` over 0.2s. Contrast is a
+  // property of the *resting* states, and sampling mid-interpolation makes the
+  // reading depend on machine load — so freeze the transition rather than try
+  // to wait it out. (Polling for two equal frames does not work: a transition's
+  // start time is the frame it is first sampled on, so the first two samples
+  // both read the `from` value and the poll exits at progress 0.)
+  await page.addStyleTag({
+    content: '.cc-toggle-slider, .cc-toggle-slider::before { transition: none !important; }',
+  });
+
+  await page.click('[data-cc="manage"]');
+  await expect(page.locator('#cc-modal')).toHaveClass(/cc-visible/);
+}
+
+/** `analytics` defaults to false in the playground config, so it renders unchecked. */
+function suite(label: string) {
+  test(`${label}: off-state toggle clears 3:1 on both boundaries`, async ({ page }) => {
+    await openPreferences(page);
+    const { track, knob, trackColor } = await readToggleContrast(page, 'analytics');
+
+    expect(trackColor, 'off track should paint --cc-toggle-off').toBe(
+      await resolveToken(page, '--cc-toggle-off'),
+    );
+
+    expect(track, `off track vs backdrop (${label})`).toBeGreaterThanOrEqual(MIN_RATIO);
+    expect(knob, `off knob vs track (${label})`).toBeGreaterThanOrEqual(MIN_RATIO);
+  });
+
+  test(`${label}: on-state toggle clears 3:1 on both boundaries`, async ({ page }) => {
+    await openPreferences(page);
+    await page.click('label.cc-toggle:has(input[data-cc-category="analytics"])');
+    await expect(page.locator('input[data-cc-category="analytics"]')).toBeChecked();
+
+    const { track, knob, trackColor } = await readToggleContrast(page, 'analytics');
+
+    // Pin what was actually measured: without this the test can silently
+    // re-measure the off state and still pass.
+    expect(trackColor, 'on track should paint --cc-primary').toBe(
+      await resolveToken(page, '--cc-primary'),
+    );
+
+    expect(track, `on track vs backdrop (${label})`).toBeGreaterThanOrEqual(MIN_RATIO);
+    expect(knob, `on knob vs track (${label})`).toBeGreaterThanOrEqual(MIN_RATIO);
+  });
+}
+
+test.describe('Toggle contrast — light palette', () => {
+  test.use({ colorScheme: 'light' });
+  suite('light');
+});
+
+test.describe('Toggle contrast — dark palette', () => {
+  // `ui.colorMode: 'auto'` leaves `data-cc-theme` unset, so this drives the
+  // `@media (prefers-color-scheme: dark)` block in base.css.
+  test.use({ colorScheme: 'dark' });
+  suite('dark');
+});

--- a/playground/src/pages/gcm.astro
+++ b/playground/src/pages/gcm.astro
@@ -27,8 +27,9 @@ import Layout from '../layouts/Layout.astro';
   <h1>Google Consent Mode v2</h1>
   <p>
     The <code>googleConsentMode</code> config emits a
-    <code>gtag('consent', 'default', …)</code> call inline at the top of
-    <code>&lt;head&gt;</code>, then bridges
+    <code>gtag('consent', 'default', …)</code> call inline at the end of
+    <code>&lt;head&gt;</code> — before anything in <code>&lt;body&gt;</code>
+    — then bridges
     <code>astro-consent:consent</code> / <code>astro-consent:change</code>
     into <code>gtag('consent', 'update', …)</code>.
   </p>


### PR DESCRIPTION
Fixes the three defects reported against 0.3.3. Ships as **0.3.4** (patch — no API changes).

Closes #115
Closes #116
Closes #117

## #115 — GCM default snippet is not at the top of `<head>`

The README, the `googleConsentMode` doc comments (which ship in `dist/types.d.ts`, so the editor tooltip was wrong too) and both Google recipes claimed the consent-default snippet lands "at the top of `<head>`". It does not — Astro emits injected `head-inline` scripts *after* the route's own `<head>` content, so it is the **last** thing in `<head>`. Verified against the built output: in `playground/dist/gcm/index.html` the snippet sits after charset, title, `ClientRouter`, the stylesheet and the page module.

Corrected in all 9 places across 6 files. Both recipes now place the Google tag at the **top of `<body>`** — ordered after the whole of `<head>` by the HTML parser, so the guarantee is real rather than the async-scheduling accident the issue describes — with the integration-ordering approach documented as the in-`<head>` alternative.

The README's GA4 example was additionally broken on its own terms: unlike `docs/recipes/ga4.md`, it called bare `gtag('js', …)` / `gtag('config', …)` without bootstrapping `window.dataLayer` and `gtag`. Combined with the old "drop your tag **anywhere in your layout**" advice, following it into `<head>` threw `ReferenceError: gtag is not defined` and dropped the GA4 config entirely.

No runtime behaviour changed — the snippet lands where it always did.

For the record: the GTM case in the issue title does not actually break, since `gtm.md` sets `j.async=true` and the only pre-consent `dataLayer` entry is the `gtm.start` marker. The README's GA4 snippet was the real failure.

## #116 — toggle off-state fails WCAG 2.1 SC 1.4.11

`.cc-toggle-slider` painted its off track with `--cc-border` and its knob with hard-coded `white`. `--cc-border` could not be fixed in place because it also draws the banner hairline, the `.cc-badge` outline, and the secondary button's border **and** hover fill — 5 consumption sites.

Adds `--cc-toggle-off` / `--cc-toggle-knob` to all four palette blocks. Ratios are measured against the composited `.cc-category` card the toggle actually sits on (`rgba(var(--cc-tint-rgb), .02)` → `#fafafa` light / `#232d3f` dark), not `--cc-bg`:

| | track vs card | knob vs track |
|---|---|---|
| before (light) | 1.18:1 ❌ | 1.23:1 ❌ |
| before (dark) | 1.93:1 ❌ | 7.58:1 ✅ |
| after — light `#64748b` | **4.56:1** ✅ | **4.76:1** ✅ |
| after — dark `#7a8699` | **3.75:1** ✅ | **3.69:1** ✅ |

Consumers overriding `--cc-border` keep their hairline and get a legible toggle; the new tokens are documented in the theming section.

## #117 — `essentialBadge` undocumented

The key appeared **nowhere** in the README — not in the `ConsentText` reference block, not in the localization example — so anyone localizing from the docs shipped a stray English "Required" pill next to a fully translated Essential row. Both places now list it. Czech value is `Vždy zapnuto`; reusing the label would render "Nezbytné Nezbytné", since label and badge are adjacent siblings.

## Test coverage

None of the three would have been caught by the existing suite — `gcm.spec.ts` asserted `dataLayer` contents but never DOM position, and no spec read a colour.

- `playground/e2e/gcm.spec.ts` — 2 tests pinning the snippet inside `<head>` and ahead of the page's own `gtag` calls.
- `playground/e2e/toggle-contrast.spec.ts` — 4 tests computing the real composited ratios in both palettes, for both states.

Both guards were falsified before landing: reintroducing each bug fails them deterministically (10/10 runs), and they pass on the fixed tree.

`59 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
