### PR TITLE
feat: themeable banner width via --cc-banner-max-width

### DIFF
--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,0 +1,46 @@
+---
+'@zdenekkurecka/astro-consent': patch
+---
+
+Make the bottom banner's content width themeable via `--cc-banner-max-width`
+and `--cc-banner-text-min-width`.
+
+`.cc-banner-inner` capped its centered content at a hard-coded `72rem`, and
+`.cc-banner-text` held a hard-coded `min-width: 280px`. Both are now custom
+properties defaulting to those same values, so the rendered result is
+unchanged.
+
+Every other visual knob in this package is already a `--cc-*` token whose
+default is declared at zero specificity inside `:where(:root)` — the reason a
+consumer's `:root { --cc-primary: … }` reliably wins without `!important`.
+Width was the one dimension that escaped that convention, so matching the bar
+to a site's own grid meant overriding `.cc-banner-inner` directly. That is a
+class-vs-class tie at equal specificity, decided by stylesheet source order,
+and consumers do not control that order: the base stylesheet is injected via
+`injectScript('page-ssr', …)` and Astro decides where the resulting `<link>`
+lands relative to their own. In practice that pushed people to `!important` or
+a specificity hack, and pinned them to a class name this package treats as
+internal.
+
+```css
+:root {
+  --cc-banner-max-width: 80rem; /* or `none` for a full-bleed bar */
+  --cc-banner-text-min-width: 200px;
+}
+```
+
+The two tokens are documented together because they interact: the banner's
+message and its buttons share a row only while the content box is wider than
+both combined, so narrowing the bar while leaving the text floor at `280px`
+makes the buttons wrap onto their own row sooner than the chosen width
+suggests.
+
+Deliberately a CSS token rather than a `ui.*` config option: an option would
+have to emit an inline `style` attribute, which would break the `style-src
+'self'` guarantee the README makes for strict Content Security Policies.
+
+Covered by a new e2e spec that pins the defaults to the values the literals
+rendered, overrides both tokens through a stylesheet rather than an inline
+style so the cascade against the injected sheet is what is actually asserted,
+and derives the wrap threshold from the measured button width rather than
+hard-coding a number that moves with the playground's labels.

--- a/README.md
+++ b/README.md
@@ -725,6 +725,27 @@ the secondary button), while the toggle's off state has to clear
 leaves the toggle legible. If you do restyle the toggle, keep both the track
 against the category card *and* the knob against the track at 3:1 or better.
 
+Layout is themeable the same way. The bottom banner bar is always full-bleed;
+what `--cc-banner-max-width` caps is the content centered inside it, so you can
+line the bar up with your own grid instead of overriding `.cc-banner-inner`:
+
+```css
+:root {
+  --cc-banner-max-width: 80rem; /* default 72rem; `none` for full-bleed */
+}
+```
+
+If you go *narrower*, lower `--cc-banner-text-min-width` (default `280px`) in
+step with it. That token is the width the message refuses to shrink below, and
+the banner's buttons share its row only while the content box is wider than the
+two of them together — leave the floor at `280px` under a narrow bar and the
+buttons wrap onto their own row earlier than the width you set implies.
+
+Both are plain custom properties on `:root`, so they inherit the same
+zero-specificity defaults as the color tokens: your override wins on cascade
+without `!important` and without depending on a class name this package treats
+as internal.
+
 ### Use with a strict Content Security Policy
 
 The integration is compatible with strict CSPs out of the box:

--- a/packages/astro-consent/src/styles/base.css
+++ b/packages/astro-consent/src/styles/base.css
@@ -16,6 +16,15 @@
   --cc-radius: 1.5rem;
   --cc-radius-pill: 9999px;
   --cc-font-family: inherit;
+
+  /* Layout. The banner bar itself is always full-bleed; these size the
+   * centered content inside it. `--cc-banner-max-width: none` makes the
+   * content full-bleed too. `--cc-banner-text-min-width` is the width the
+   * message refuses to shrink below before the actions wrap onto their own
+   * row — lower it in step with a narrower bar, or the actions wrap sooner
+   * than the width you asked for implies. */
+  --cc-banner-max-width: 72rem;
+  --cc-banner-text-min-width: 280px;
 }
 
 /* ── Dark mode defaults (prefers-color-scheme) ──────────────
@@ -116,7 +125,7 @@
 }
 
 .cc-banner-inner {
-  max-width: 72rem;
+  max-width: var(--cc-banner-max-width);
   margin: 0 auto;
   padding: 1rem 1.5rem;
   display: flex;
@@ -128,7 +137,7 @@
 
 .cc-banner-text {
   flex: 1 1 0%;
-  min-width: 280px;
+  min-width: var(--cc-banner-text-min-width);
   margin: 0;
   font-size: 0.875rem;
   line-height: 1.5;

--- a/playground/e2e/banner-width.spec.ts
+++ b/playground/e2e/banner-width.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect, type Page } from '@playwright/test';
+import { clearConsent } from './helpers';
+
+/**
+ * Regression guard for the banner layout tokens.
+ *
+ * `--cc-banner-max-width` and `--cc-banner-text-min-width` replaced two
+ * hard-coded values in `.cc-banner-inner` / `.cc-banner-text`. Two things have
+ * to keep holding:
+ *
+ *   1. The defaults render exactly what the literals did, so the change is
+ *      invisible to anyone who never sets them.
+ *   2. A consumer's plain `:root { --cc-* }` rule wins. That is the whole
+ *      point of the token: the package's own default is declared inside
+ *      `:where(:root)` at zero specificity, so the override needs no
+ *      `!important` and no dependency on `.cc-banner-inner` — a class this
+ *      package treats as internal. We therefore override via `addStyleTag`
+ *      (a real cascade fight against the injected stylesheet) rather than by
+ *      setting an inline style, which would win regardless and prove nothing.
+ */
+
+const REM = 16;
+
+/** Widths of the pieces that compete for a row inside `.cc-banner-inner`. */
+async function measure(page: Page) {
+  return page.evaluate(() => {
+    const inner = document.querySelector('.cc-banner-inner') as HTMLElement;
+    const text = document.querySelector('.cc-banner-text') as HTMLElement;
+    const actions = document.querySelector('.cc-banner-actions') as HTMLElement;
+    const cs = getComputedStyle(inner);
+    const t = text.getBoundingClientRect();
+    const a = actions.getBoundingClientRect();
+    return {
+      maxWidth: cs.maxWidth,
+      width: Math.round(inner.getBoundingClientRect().width),
+      padX: parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight),
+      gap: parseFloat(cs.columnGap),
+      textMinWidth: getComputedStyle(text).minWidth,
+      actions: Math.round(a.width),
+      // Flex-wrapped items stack, so the actions start after the text ends
+      // only while the two share a row. `align-items: center` makes a
+      // top-coordinate comparison unreliable when the text is taller.
+      sameRow: a.left >= t.right - 1,
+    };
+  });
+}
+
+test.describe('Banner width tokens', () => {
+  // Comfortably above the 480px breakpoint, where `.cc-banner-actions`
+  // becomes a full-width grid and the row question stops being meaningful.
+  test.use({ viewport: { width: 1600, height: 900 } });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await clearConsent(page);
+    await page.reload();
+    await expect(page.locator('#cc-banner')).toHaveClass(/cc-visible/);
+  });
+
+  test('defaults are unchanged: 72rem cap, 280px text floor', async ({ page }) => {
+    const m = await measure(page);
+    expect(m.maxWidth).toBe(`${72 * REM}px`);
+    expect(m.width).toBe(72 * REM);
+    expect(m.textMinWidth).toBe('280px');
+  });
+
+  test('a consumer :root rule narrows the bar without !important', async ({ page }) => {
+    await page.addStyleTag({ content: ':root { --cc-banner-max-width: 50rem; }' });
+    const m = await measure(page);
+    expect(m.maxWidth).toBe(`${50 * REM}px`);
+    expect(m.width).toBe(50 * REM);
+  });
+
+  test('`none` makes the content full-bleed', async ({ page }) => {
+    await page.addStyleTag({ content: ':root { --cc-banner-max-width: none; }' });
+    const m = await measure(page);
+    expect(m.maxWidth).toBe('none');
+    // The bar is fixed to both edges, so uncapped content fills the viewport.
+    expect(m.width).toBe(1600);
+  });
+
+  test('the text floor decides where the actions wrap', async ({ page }) => {
+    const base = await measure(page);
+
+    // Pick a bar narrow enough that the message gets less room than the
+    // default 280px floor, but more than a lowered one. Derived from the
+    // measured button width so the test does not hard-code a value that
+    // shifts with the playground's labels or locale.
+    const roomForText = 200;
+    expect(roomForText).toBeLessThan(280);
+    const cap = base.actions + base.gap + roomForText + base.padX;
+
+    await page.addStyleTag({ content: `:root { --cc-banner-max-width: ${cap}px; }` });
+    const tight = await measure(page);
+    expect(tight.width).toBe(Math.round(cap));
+    expect(tight.sameRow, 'default 280px floor should push the actions onto their own row')
+      .toBe(false);
+
+    await page.addStyleTag({ content: ':root { --cc-banner-text-min-width: 120px; }' });
+    const lowered = await measure(page);
+    expect(lowered.textMinWidth).toBe('120px');
+    expect(lowered.sameRow, 'lowering the floor should recover the shared row').toBe(true);
+  });
+});


### PR DESCRIPTION
Makes the bottom banner's content width themeable, releasing as **0.3.5**.

## What changed

`.cc-banner-inner` capped its centered content at a hard-coded `72rem` and `.cc-banner-text` held a hard-coded `min-width: 280px`. Both are now custom properties defaulting to those same values:

```css
--cc-banner-max-width: 72rem;
--cc-banner-text-min-width: 280px;
```

Nothing renders differently unless you set them.

## Why

Every other visual knob in this package is a `--cc-*` token whose default is declared at zero specificity inside `:where(:root)` — that's why a consumer's `:root { --cc-primary: … }` wins without `!important`. Width was the one dimension that escaped the convention, so matching the bar to a site's own grid meant overriding `.cc-banner-inner` directly. That's a class-vs-class tie at equal specificity, decided by stylesheet source order the consumer doesn't control: the sheet is injected via `injectScript('page-ssr', …)` and Astro decides where the resulting `<link>` lands. In practice that pushed people to `!important` or a specificity hack, against a class this package treats as internal.

Kept as a CSS token rather than a `ui.*` config option deliberately — an option would have to emit an inline `style` attribute and break the `style-src 'self'` guarantee the README makes for strict CSPs.

## Verified in a browser

| override | rendered |
| --- | --- |
| *(none)* | 1152px — identical to the old literal |
| `--cc-banner-max-width: 80rem` | 1280px |
| `--cc-banner-max-width: none` | full-bleed |

The two tokens interact, so they're documented together: the message and the buttons share a row only while the content box is wider than both combined. Measured on the playground, at ~42rem the default 280px floor pushes the buttons onto their own row while 180px keeps them inline; at 46rem+ the floor is moot.

## Coverage

New `playground/e2e/banner-width.spec.ts` (4 tests). It overrides via a stylesheet rather than an inline style, so what's asserted is the real cascade against the injected sheet — an inline style would win regardless and prove nothing. The wrap threshold is derived from the measured button width instead of a hard-coded number that moves with labels or locale.

Full suite: 63/63 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUdxMMjo4cqueNszZWP4HL